### PR TITLE
Clean up test artifact creation

### DIFF
--- a/test/Shared/DisposableDirectory.cs
+++ b/test/Shared/DisposableDirectory.cs
@@ -6,7 +6,7 @@ public readonly record struct TempDirectory(string Path) : IDisposable
 {
     public static TempDirectory CreateSubDirectory(string basePath)
     {
-        string dir = IOPath.Combine(basePath, Guid.NewGuid().ToString());
+        string dir = IOPath.Combine(basePath, IOPath.GetRandomFileName());
         Directory.CreateDirectory(dir);
         return new TempDirectory(dir);
     }

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -139,7 +139,7 @@ public sealed class MockServer : IAsyncDisposable
 
     private static void GetSdk(HttpListenerResponse response)
     {
-        using var f = Assets.GetOrMakeFakeSdkArchive();
+        var f = Assets.SdkArchive;
         var streamLength = f.Length;
         response.ContentLength64 = streamLength;
         f.CopyTo(response.OutputStream);

--- a/test/Shared/assets/fakesdk-42.42.42/dotnet
+++ b/test/Shared/assets/fakesdk-42.42.42/dotnet
@@ -1,3 +1,0 @@
-#!/bin/bash
-# Arbitrary token to look for in file
-echo "2c192c853403aa1725f8f99bbe72fe691226fa28"


### PR DESCRIPTION
Gets rid of dead code, and it should fix an inter-process race condition that was sometimes causing failures on Windows.