### PR TITLE
Use a symlink for selecting the right SDK install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/makeRelease.yml
+++ b/.github/workflows/makeRelease.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100
+        dotnet-version: 7.0.x
     - name: Restore local tools
       run: dotnet tool restore
     - name: Publish Windows

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100
+        dotnet-version: 7.0.x
     - name: Restore local tools
       run: dotnet tool restore
     - name: Publish Windows

--- a/src/dnvm/Update.cs
+++ b/src/dnvm/Update.cs
@@ -184,7 +184,7 @@ public sealed partial class Update
         await DownloadBinaryToTempAndDelete(artifactDownloadLink, HandleDownload);
         _logger.Info($"{tempArchiveDir} contents: {string.Join(", ", Directory.GetFiles(tempArchiveDir))}");
 
-        string dnvmTmpPath = Path.Combine(tempArchiveDir, Utilities.ExeName);
+        string dnvmTmpPath = Path.Combine(tempArchiveDir, Utilities.DnvmExeName);
         bool success =
             await ValidateBinary(_logger, dnvmTmpPath) &&
             SwapWithRunningFile(dnvmTmpPath);

--- a/src/dnvm/Utilities.cs
+++ b/src/dnvm/Utilities.cs
@@ -61,7 +61,8 @@ public static class Utilities
         ? ".exe"
         : "";
 
-    public static string ExeName = "dnvm" + ExeSuffix;
+    public static string DnvmExeName = "dnvm" + ExeSuffix;
+    public static string DotnetExeName = "dotnet" + ExeSuffix;
 
     public static async Task<string?> ExtractArchiveToDir(string archivePath, string dirPath)
     {

--- a/src/dnvm/env.sh
+++ b/src/dnvm/env.sh
@@ -7,11 +7,4 @@ case ":${PATH}:" in
         export PATH="{install_loc}:$PATH"
         ;;
 esac
-case ":${PATH}:" in
-    *:"{sdk_install_loc}":*)
-        ;;
-    *)
-        export PATH="{sdk_install_loc}:$PATH"
-        ;;
-esac
 export DOTNET_ROOT="{sdk_install_loc}"

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -132,7 +132,7 @@ echo "DOTNET_ROOT: $DOTNET_ROOT"
 
             var pathMatch = $";{Environment.GetEnvironmentVariable(PATH, EnvironmentVariableTarget.User)};";
             Assert.Contains($";{_globalOptions.DnvmInstallPath};", pathMatch);
-            Assert.Contains($";{_globalOptions.SdkInstallDir};", pathMatch);
+            Assert.DoesNotContain($";{_globalOptions.SdkInstallDir};", pathMatch);
             Assert.Equal(_globalOptions.SdkInstallDir, Environment.GetEnvironmentVariable(DOTNET_ROOT, EnvironmentVariableTarget.User));
         }
         finally

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -94,7 +94,7 @@ echo "DOTNET_ROOT: $DOTNET_ROOT"
         Assert.Equal(0, proc.ExitCode);
 
         Assert.Equal(_globalOptions.DnvmInstallPath, Path.GetDirectoryName(await ReadLine("dnvm: ")));
-        Assert.Equal(_globalOptions.SdkInstallDir, Path.GetDirectoryName(await ReadLine("dotnet: ")));
+        Assert.Equal(_globalOptions.DnvmInstallPath, Path.GetDirectoryName(await ReadLine("dotnet: ")));
         Assert.Equal(_globalOptions.SdkInstallDir, await ReadLine("DOTNET_ROOT: "));
 
         async Task<string> ReadLine(string expectedPrefix)


### PR DESCRIPTION
Using a symlink allows for installing SDKs to multiple directories and retargeting to individual installs based on user commands.