### PR TITLE
Rework self-update

### DIFF
--- a/src/dnvm/CommandLineOptions.cs
+++ b/src/dnvm/CommandLineOptions.cs
@@ -32,6 +32,12 @@ public abstract record CommandArguments
         /// or environment variables.
         /// </summary>
         public bool UpdateUserEnvironment { get; init; } = true;
+
+        /// <summary>
+        /// Only valid for self-install. Indicates that this is an update to
+        /// an existing dnvm installation.
+        /// </summary>
+        public bool Update {get; init; } = false;
     }
 
     public sealed record UpdateArguments : CommandArguments
@@ -71,24 +77,32 @@ sealed record class CommandLineArguments(CommandArguments Command)
                 bool yes = false;
                 bool prereqs = default;
                 string? feedUrl = default;
+                bool selfUpdate = false;
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
                 syntax.DefineOption("f|force", ref force, "Force install the given SDK, even if already installed");
                 syntax.DefineOption("self", ref self, "Install dnvm itself into the target location");
                 syntax.DefineOption("y", ref yes, "Answer yes to every question (or accept default).");
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
                 syntax.DefineOption("feed-url", ref feedUrl, $"Set the feed URL to download the SDK from.");
+                syntax.DefineOption("update", ref selfUpdate, "[internal] Update the dnvm installation in the current location. Only intended to be called from dnvm.");
                 syntax.DefineParameter("channel", ref channel, c =>
-                {
-                    if (Enum.TryParse<Channel>(c, ignoreCase: true, out var result))
                     {
-                        return result;
-                    }
-                    var sep = Environment.NewLine + "\t- ";
-                    throw new FormatException(
-                        "Channel must be one of:"
-                        + sep + string.Join(sep, Enum.GetNames<Channel>()));
-                },
-                $"Download from the channel specified. Defaults to '{channel.ToString().ToLowerInvariant()}'.");
+                        if (Enum.TryParse<Channel>(c, ignoreCase: true, out var result))
+                        {
+                            return result;
+                        }
+                        var sep = Environment.NewLine + "\t- ";
+                        throw new FormatException(
+                            "Channel must be one of:"
+                            + sep + string.Join(sep, Enum.GetNames<Channel>()));
+                    },
+                    $"Download from the channel specified. Defaults to '{channel.ToString().ToLowerInvariant()}'.");
+
+                if (selfUpdate && !self)
+                {
+                    throw new FormatException("The --update option can only be used with --self");
+                }
+
                 command = new CommandArguments.InstallArguments
                 {
                     Channel = channel,
@@ -98,6 +112,7 @@ sealed record class CommandLineArguments(CommandArguments Command)
                     Yes = yes,
                     Prereqs = prereqs,
                     FeedUrl = feedUrl,
+                    Update = selfUpdate,
                 };
             }
 

--- a/src/dnvm/ProcUtil.cs
+++ b/src/dnvm/ProcUtil.cs
@@ -38,5 +38,26 @@ public static class ProcUtil
             await error.ConfigureAwait(false));
     }
 
+    public static async Task<ProcResult> RunShell(string scriptContent)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true
+        };
+        var proc = Process.Start(psi)!;
+        await proc.StandardInput.WriteAsync(scriptContent);
+        proc.StandardInput.Close();
+        var @out = proc.StandardOutput.ReadToEndAsync();
+        var error = proc.StandardError.ReadToEndAsync();
+        await proc.WaitForExitAsync().ConfigureAwait(false);
+        return new ProcResult(
+            proc.ExitCode,
+            await @out.ConfigureAwait(false),
+            await error.ConfigureAwait(false));
+    }
+
     public readonly record struct ProcResult(int ExitCode, string Out, string Error);
 }

--- a/test/Shared/Assets.cs
+++ b/test/Shared/Assets.cs
@@ -17,7 +17,8 @@ public sealed class Assets
     private static Lazy<byte[]> s_sdkArchive = new Lazy<byte[]>(() =>
     {
         using var tempDir = TestUtils.CreateTempDirectory();
-        var exePath = MakeFakeExe(Path.Combine(tempDir.Path, "dotnet"), ArchiveToken);
+        var exePath = Path.Combine(tempDir.Path, Utilities.DotnetExeName);
+        MakeFakeExe(exePath, ArchiveToken);
         using var zipDir = TestUtils.CreateTempDirectory();
         var archivePath = MakeZipOrTarball(tempDir.Path, Path.Combine(zipDir.Path, "dotnet"));
         var archive = File.ReadAllBytes(archivePath);
@@ -28,9 +29,8 @@ public sealed class Assets
 
     public static Stream SdkArchive => new MemoryStream(s_sdkArchive.Value);
 
-    public static string MakeFakeExe(string destPathWithoutSuffix, string outputString)
+    public static void MakeFakeExe(string destPath, string outputString)
     {
-        var destPath = destPathWithoutSuffix + Utilities.ExeSuffix;
         switch (Environment.OSVersion.Platform)
         {
             case PlatformID.Unix:
@@ -71,7 +71,6 @@ class Program {
             case var p:
                 throw new InvalidOperationException("Unsupported platform: " + p);
         }
-        return destPath;
     }
 
     public static string MakeZipOrTarball(string srcDir, string destPathWithoutSuffix)
@@ -102,7 +101,8 @@ class Program {
         // rather than use an actual copy of dnvm, we'll use an executable bash/powershell script
         const string outputString = "Hello from dnvm test. This output must contain the string << usage: >>";
         using var tmpDir = TestUtils.CreateTempDirectory();
-        var dnvmPath = MakeFakeExe(Path.Combine(tmpDir.Path, "dnvm"), outputString);
+        var dnvmPath = Path.Combine(tmpDir.Path, Utilities.DnvmExeName);
+        MakeFakeExe(dnvmPath, outputString);
         var archivePath = MakeZipOrTarball(tmpDir.Path, Path.Combine(ArtifactsTmpDir.FullName, "dnvm"));
         return File.Open(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read);
     }


### PR DESCRIPTION
Currently self-update is something done entirely by the originating binary -- it checks for available updates, downloads the updaate, and swaps the new binary in for the old.

This means that the new binary doesn't have a chance to run any program logic.

The new model is to download the new binary, and then run it in an installer mode. This will let the binary install itself, running whatever's necessary to do so.