### PR TITLE
Fix GetLatestReleaseForChannel

### DIFF
--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -30,18 +30,19 @@ public partial record DotnetReleasesIndex
             {
                 continue;
             }
-            switch (c)
+            var found = (c, supportPhase, releaseType) switch
             {
-                case Channel.Latest when supportPhase is "active":
-                case Channel.Lts when releaseType is "lts":
-                case Channel.Sts when releaseType is "sts":
-                case Channel.Preview when supportPhase is "preview":
-                    if (latestRelease is not { } latest ||
-                        SemVersion.ComparePrecedence(releaseVersion, latest.Version) > 0)
-                    {
-                        latestRelease = (release, releaseVersion);
-                    }
-                   break;
+                (Channel.Latest, "active", _)
+                or (Channel.Lts, "active", "lts")
+                or (Channel.Sts, "active", "sts")
+                or (Channel.Preview, "preview", _) => true,
+                _ => false
+            };
+            if (found &&
+                (latestRelease is not { } latest ||
+                 SemVersion.ComparePrecedence(releaseVersion, latest.Version) > 0))
+            {
+                latestRelease = (release, releaseVersion);
             }
         }
         return latestRelease?.Release;

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -128,6 +128,11 @@ public readonly partial record struct SdkDirName(string Name);
 
 public static partial class ManifestUtils
 {
+    /// <summary>
+    /// Reads a manifest (any version) from the given path and returns
+    /// an up-to-date <see cref="Manifest" /> (latest version).
+    /// Throws <see cref="InvalidDataException" /> if the manifest is invalid.
+    /// </summary>
     public static Manifest ReadManifest(string manifestPath)
     {
         var text = File.ReadAllText(manifestPath);


### PR DESCRIPTION
This function is meant to find the newest release in a given channel. It now properly excludes preview releases, unless the channel is a preview channel.