### PR TITLE
Add VFS abstraction for testing

### DIFF
--- a/src/Vfs/IVfs.cs
+++ b/src/Vfs/IVfs.cs
@@ -1,0 +1,10 @@
+
+using System.Threading.Tasks;
+
+namespace Vfs;
+
+public interface IVfs
+{
+    Task<string> ReadAllTextAsync(VfsPath manifestPath);
+    Task WriteAllText(VfsPath manifest, string text);
+}

--- a/src/Vfs/MemoryFs.cs
+++ b/src/Vfs/MemoryFs.cs
@@ -1,0 +1,22 @@
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using static System.Text.Encoding;
+
+namespace Vfs;
+
+public sealed class MemoryFs : IVfs
+{
+    private readonly Dictionary<VfsPath, byte[]> _files = new();
+
+    public Task<string> ReadAllTextAsync(VfsPath manifestPath)
+    {
+        return Task.FromResult(UTF8.GetString(_files[manifestPath]));
+    }
+
+    public Task WriteAllText(VfsPath manifest, string text)
+    {
+        _files[manifest] = UTF8.GetBytes(text);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Vfs/OsFs.cs
+++ b/src/Vfs/OsFs.cs
@@ -1,0 +1,26 @@
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Vfs;
+
+public sealed class OsFs : IVfs
+{
+    private readonly string _basePath;
+    public OsFs(string basePath)
+    {
+        _basePath = basePath;
+    }
+
+    private string GetOsPath(VfsPath vfsPath) => Path.Combine(_basePath, vfsPath.ToString()[1..]);
+
+    public Task<string> ReadAllTextAsync(VfsPath path)
+    {
+        return File.ReadAllTextAsync(GetOsPath(path));
+    }
+
+    public async Task WriteAllText(VfsPath path, string text)
+    {
+        await File.WriteAllTextAsync(GetOsPath(path), text);
+    }
+}

--- a/src/Vfs/Vfs.csproj
+++ b/src/Vfs/Vfs.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Vfs/VfsPath.cs
+++ b/src/Vfs/VfsPath.cs
@@ -1,0 +1,89 @@
+
+using System;
+using System.Collections;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Vfs;
+
+public sealed class VfsPath : IEquatable<VfsPath>
+{
+    // VFS paths are unique to a given IVfs instance.
+    private readonly IVfs _vfs;
+
+    private readonly ImmutableArray<string> _parts;
+
+    /// <summary>
+    /// Create a new root VFS path.
+    /// </summary>
+    public VfsPath(IVfs vfs)
+    {
+        _vfs = vfs;
+        _parts = ImmutableArray<string>.Empty;
+    }
+
+    private VfsPath(IVfs vfs, ImmutableArray<string> parts)
+    {
+        _vfs = vfs;
+        _parts = parts;
+    }
+
+    /// <summary>
+    /// Create a new VFS path relative to this path. The incoming path must be relative.  Resolves
+    /// "." and ".." parts. If the resolved path would be outside the root, the root is returned
+    /// instead.
+    /// </summary>
+    public VfsPath Combine(string relativePath)
+    {
+        if (relativePath.StartsWith('/'))
+        {
+            throw new ArgumentException("Path must be relative", nameof(relativePath));
+        }
+
+        var parts = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var builder = ImmutableArray.CreateBuilder<string>();
+        builder.AddRange(_parts);
+
+        // Add parts while handling "." and ".."
+        foreach (var part in parts)
+        {
+            if (part == ".")
+            {
+                continue;
+            }
+            if (part == "..")
+            {
+                if (builder.Count > 0)
+                {
+                    builder.RemoveAt(builder.Count - 1);
+                }
+                continue;
+            }
+            builder.Add(part);
+        }
+
+        return new VfsPath(this._vfs, builder.ToImmutable());
+    }
+
+    public override string ToString() => '/' + string.Join('/', _parts);
+
+    public override bool Equals(object? obj) => Equals(obj as VfsPath);
+
+    public bool Equals(VfsPath? other)
+    {
+        return other is not null
+            && object.ReferenceEquals(this._vfs, other._vfs)
+            && this._parts.SequenceEqual(other._parts);
+    }
+
+    public override int GetHashCode()
+    {
+        int code = 0;
+        code = HashCode.Combine(code, _vfs);
+        foreach (var item in _parts)
+        {
+            code = HashCode.Combine(code, item);
+        }
+        return code;
+    }
+}

--- a/src/dnvm/DnvmHome.cs
+++ b/src/dnvm/DnvmHome.cs
@@ -1,0 +1,41 @@
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Serde.Json;
+using Vfs;
+
+namespace Dnvm;
+
+public sealed class DnvmHome
+{
+    public const string ManifestFileName = "dnvmManifest.json";
+
+    public readonly IVfs Vfs;
+    private readonly VfsPath _root;
+
+    public VfsPath ManifestPath => _root.Combine(ManifestFileName);
+
+    public DnvmHome(IVfs vfs)
+    {
+        Vfs = vfs;
+        _root = new VfsPath(vfs);
+    }
+
+    /// <summary>
+    /// Reads a manifest (any version) from the given path and returns
+    /// an up-to-date <see cref="Manifest" /> (latest version).
+    /// Throws <see cref="InvalidDataException" /> if the manifest is invalid.
+    /// </summary>
+    public async Task<Manifest> ReadManifest()
+    {
+        var text = await Vfs.ReadAllTextAsync(ManifestPath);
+        return ManifestUtils.DeserializeNewOrOldManifest(text) ?? throw new InvalidDataException();
+    }
+
+    public Task WriteManifest(Manifest manifest)
+    {
+        var text = JsonSerializer.Serialize(manifest);
+        return Vfs.WriteAllText(ManifestPath, text);
+    }
+}

--- a/src/dnvm/List.cs
+++ b/src/dnvm/List.cs
@@ -6,30 +6,24 @@ namespace Dnvm;
 
 public static class ListCommand
 {
-    public static Task<int> Run(Logger logger, GlobalOptions globalOptions)
-    {
-        var manifestPath = globalOptions.ManifestPath;
-        return Run(logger, manifestPath);
-    }
-
     /// <summary>
     /// Prints a list of installed SDK versions and their locations.
-    private static Task<int> Run(Logger logger, string manifestPath)
+    public async static Task<int> Run(Logger logger, DnvmHome home)
     {
         Manifest manifest;
         try
         {
-            manifest = ManifestUtils.ReadManifest(manifestPath);
+            manifest = await home.ReadManifest();
         }
         catch (Exception e)
         {
             logger.Error("Error reading manifest: " + e.Message);
-            return Task.FromResult(1);
+            return 1;
         }
 
         PrintSdks(logger, manifest);
 
-        return Task.FromResult(0);
+        return 0;
     }
 
     public static void PrintSdks(Logger logger, Manifest manifest)

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -197,7 +197,7 @@ public static partial class ManifestUtils
     /// Either reads a manifest in the current format, or reads a
     /// manifest in the old format and converts it to the new format.
     /// </summary>
-    private static Manifest? DeserializeNewOrOldManifest(string manifestSrc)
+    public static Manifest? DeserializeNewOrOldManifest(string manifestSrc)
     {
         try
         {

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Semver;
+using Vfs;
 
 namespace Dnvm;
 
@@ -18,13 +19,14 @@ public static class Program
         Console.WriteLine();
         var options = CommandLineArguments.Parse(args);
         var logger = new Logger(Console.Out, Console.Error);
-        var dnvmHome = GetGlobalConfig();
+        var globalOptions = GetGlobalConfig();
+        var home = new DnvmHome(new OsFs(globalOptions.DnvmHome));
         return options.Command switch
         {
-            CommandArguments.InstallArguments o => (int)await Install.Run(dnvmHome, logger, o),
-            CommandArguments.UpdateArguments o => (int)await Update.Run(dnvmHome, logger, o),
-            CommandArguments.ListArguments => (int)await ListCommand.Run(logger, dnvmHome),
-            CommandArguments.SelectArguments o => await SelectCommand.Run(dnvmHome, logger, o),
+            CommandArguments.InstallArguments o => (int)await Install.Run(globalOptions, logger, o),
+            CommandArguments.UpdateArguments o => (int)await Update.Run(globalOptions, logger, o),
+            CommandArguments.ListArguments => (int)await ListCommand.Run(logger, home),
+            CommandArguments.SelectArguments o => await SelectCommand.Run(globalOptions, logger, o),
             _ => throw new InvalidOperationException("Should be unreachable")
         };
     }

--- a/src/dnvm/dnvm.csproj
+++ b/src/dnvm/dnvm.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="StaticCs.Collections" Version="1.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Vfs\Vfs.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/test/UnitTests/VfsTests.cs
+++ b/test/UnitTests/VfsTests.cs
@@ -1,0 +1,27 @@
+
+using Microsoft.VisualBasic;
+using Xunit;
+
+namespace Vfs;
+
+public sealed class VfsTests
+{
+    [Fact]
+    public void DotDotCantGoAboveRoot()
+    {
+        var path = new VfsPath(ThrowingVfs.Instance);
+        Assert.Equal("/", path.ToString());
+        path = path.Combine("..");
+        Assert.Equal("/", path.ToString());
+    }
+
+    /// <summary>
+    /// A VFS that throws on all operations.
+    /// </summary>
+    private sealed class ThrowingVfs : IVfs
+    {
+        public static readonly ThrowingVfs Instance = new();
+        public Task<string> ReadAllTextAsync(VfsPath manifestPath) => throw new NotImplementedException();
+        public Task WriteAllText(VfsPath manifest, string text) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Basic VFS abstraction that supports in-memory files. Only used for ListTests right now, but should eventually be used for all file I/O in dnvm.