### PR TITLE
Use a cmd file on windows instead of symlink

### DIFF
--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.IO.Compression;
 using System.IO.Enumeration;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
@@ -83,6 +84,9 @@ public static class Utilities
 
     public static string DnvmExeName = "dnvm" + ExeSuffix;
     public static string DotnetExeName = "dotnet" + ExeSuffix;
+    public static string DotnetSymlinkName = "dotnet" + (OperatingSystem.IsWindows()
+        ? ".cmd"
+        : "");
 
     public static async Task<string?> ExtractArchiveToDir(string archivePath, string dirPath)
     {


### PR DESCRIPTION
The dotnet.exe muxer doesn't work properly with symlinks on Windows, so a cmd file is the best solution.