### PR TITLE
Catch HttpListenerException when stopping

### DIFF
--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -85,9 +85,9 @@ public sealed class MockServer : IAsyncDisposable
             {
                 break;
             }
-            catch (HttpListenerException e)
+            catch (HttpListenerException e) when (e.ErrorCode == 995) // ERROR_OPERATION_ABORTED
             {
-                throw new InvalidOperationException("Error code " + e.ErrorCode);
+                break;
             }
 
             if (UrlToHandler.TryGetValue(ctx.Request.Url!.LocalPath.ToLowerInvariant(), out var action))

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -85,6 +85,11 @@ public sealed class MockServer : IAsyncDisposable
             {
                 break;
             }
+            catch (HttpListenerException e)
+            {
+                throw new InvalidOperationException("Error code " + e.ErrorCode);
+            }
+
             if (UrlToHandler.TryGetValue(ctx.Request.Url!.LocalPath.ToLowerInvariant(), out var action))
             {
                 action(ctx.Response);


### PR DESCRIPTION
HttpListenerException is thrown from GetContextAsync when listening is stopped. We can catch it and proceed without error.