### PR TITLE
Fix more race conditions in closing HttpListener

### DIFF
--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -12,6 +12,7 @@ public sealed class MockServer : IAsyncDisposable
     private readonly HttpListener _listener;
     private readonly TaskScope _scope;
     public int Port { get; }
+    private volatile bool _disposing = false;
 
     public string PrefixString => $"http://localhost:{Port}/";
     public string DnvmReleasesUrl => PrefixString + "releases.json";
@@ -88,12 +89,9 @@ public sealed class MockServer : IAsyncDisposable
             {
                 ctx = await _listener.GetContextAsync();
             }
-            catch (ObjectDisposedException)
+            catch when (_disposing)
             {
-                break;
-            }
-            catch (HttpListenerException e) when (e.ErrorCode == 995) // ERROR_OPERATION_ABORTED
-            {
+                // Ignore all exceptions while disposing
                 break;
             }
 
@@ -169,6 +167,7 @@ public sealed class MockServer : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
+        _disposing = true;
         try
         {
             _listener.Stop();


### PR DESCRIPTION
Chatch all exceptions from _listener.GetContextAsync when the mock server is being disposed.