### PR TITLE
Add untrack command

### DIFF
--- a/src/dnvm/CommandLineArguments.cs
+++ b/src/dnvm/CommandLineArguments.cs
@@ -77,6 +77,11 @@ public abstract record CommandArguments
     {
         public required string SdkDirName { get; init; }
     }
+
+    public sealed record UntrackArguments : CommandArguments
+    {
+        public required Channel Channel { get; init; }
+    }
 }
 
 sealed record class CommandLineArguments(CommandArguments Command)
@@ -194,6 +199,29 @@ sealed record class CommandLineArguments(CommandArguments Command)
                 command = new CommandArguments.SelectArguments
                 {
                     SdkDirName = sdkDirName,
+                };
+            }
+
+            var untrack = syntax.DefineCommand("untrack", ref commandName, "Remove a channel from the list of tracked channels");
+            if (untrack.IsActive)
+            {
+                Channel? channel = null;
+                syntax.DefineParameter("channel", ref channel, c =>
+                    {
+                        if (Enum.TryParse<Channel>(c, ignoreCase: true, out var result))
+                        {
+                            return result;
+                        }
+                        var sep = Environment.NewLine + "\t- ";
+                        throw new FormatException(
+                            "Channel must be one of:"
+                            + sep + string.Join(sep, Enum.GetNames<Channel>()));
+                    },
+                    $"Remove the given channel from the list of tracked channels.");
+
+                command = new CommandArguments.UntrackArguments
+                {
+                    Channel = channel!.Value,
                 };
             }
         });

--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -42,7 +42,7 @@ public sealed class DnvmEnv : IDisposable
     /// <summary>
     /// Get the path to DNVM_HOME, which is the location of the dnvm manifest
     /// and the installed SDKs. If the environment variable is not set, uses
-    /// <see cref="GlobalOptions.DefaultDnvmHome" /> as the default.
+    /// <see cref="DnvmEnv.DefaultDnvmHome" /> as the default.
     /// </summar>
     public static DnvmEnv CreateDefault()
     {

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Serde;
 using Serde.Json;
 using StaticCs;
@@ -87,6 +88,14 @@ public sealed partial record Manifest
             code = HashCode.Combine(code, item);
         }
         return code;
+    }
+
+    internal Manifest Untrack(Channel channel)
+    {
+        return this with
+        {
+            TrackedChannels = TrackedChannels.Where(c => c.ChannelName != channel).ToImmutableArray()
+        };
     }
 }
 

--- a/test/UnitTests/UntrackTests.cs
+++ b/test/UnitTests/UntrackTests.cs
@@ -1,0 +1,59 @@
+
+using System.Collections.Immutable;
+using Spectre.Console.Testing;
+using Xunit;
+using Zio.FileSystems;
+
+namespace Dnvm.Test;
+
+public sealed class UntrackTests
+{
+    private static Task TestWithServer(Func<MockServer, DnvmEnv, CancellationToken, Task> test)
+        => TaskScope.With(async taskScope =>
+        {
+            await using var mockServer = new MockServer(taskScope);
+            using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl);
+            await test(mockServer, testOptions.DnvmEnv, taskScope.CancellationToken);
+        });
+
+    [Fact]
+    public void ChannelUntracked()
+    {
+        var manifest = Manifest.Empty;
+        var logger = new Logger(new TestConsole());
+        var result = UntrackCommand.RunHelper(Channel.Latest, manifest, logger);
+        Assert.True(result is UntrackCommand.Result.ChannelUntracked);
+    }
+
+    [Fact]
+    public void UntrackLatest()
+    {
+        var manifest = new Manifest
+        {
+            TrackedChannels = ImmutableArray.Create(new TrackedChannel { ChannelName = Channel.Latest, SdkDirName = DnvmEnv.DefaultSdkDirName })
+        };
+        var logger = new Logger(new TestConsole());
+        var result = UntrackCommand.RunHelper(Channel.Latest, manifest, logger);
+        if (result is UntrackCommand.Result.Success({} newManifest))
+        {
+            Assert.Empty(newManifest.TrackedChannels);
+        }
+        else
+        {
+            Assert.True(false, "Expected success");
+        }
+    }
+
+    [Fact]
+    public Task InstallAndUntrack() => TestWithServer(async (mockServer, env, CancellationToken) =>
+    {
+        using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl);
+        var logger = new Logger(new TestConsole());
+        var result = await InstallCommand.Run(testOptions.DnvmEnv, logger, new CommandArguments.InstallArguments
+        {
+            Channel = Channel.Latest,
+            FeedUrl = mockServer.PrefixString
+        });
+        Assert.Equal(InstallCommand.Result.Success, result);
+    });
+}


### PR DESCRIPTION
The untrack command will remove a channel from the tracked list, meaning that the update command will no longer pull SDKs from the given channel. This also gives the opportunity to retrack the given channel and assign it to a different directory.