### PR TITLE
Accept 'go-live' as a preview release

### DIFF
--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -35,6 +35,7 @@ public partial record DotnetReleasesIndex
                 (Channel.Latest, "active", _)
                 or (Channel.Lts, "active", "lts")
                 or (Channel.Sts, "active", "sts")
+                or (Channel.Preview, "go-live", _)
                 or (Channel.Preview, "preview", _) => true,
                 _ => false
             };

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -186,4 +186,24 @@ public sealed class UpdateTests
         // LTS preview is newest
         Assert.Equal(ltsPreview, actual);
     }
+
+    [Fact]
+    public void GoLiveAcceptedAsPreview()
+    {
+        var previewRelease = new DotnetReleasesIndex.Release
+        {
+            LatestRelease = "42.42.42",
+            LatestSdk = "42.42.42",
+            MajorMinorVersion = "42.42",
+            ReleaseType = "go-live",
+            SupportPhase = "active"
+        };
+
+        var releasesIndex = new DotnetReleasesIndex {
+            Releases = ImmutableArray.Create(previewRelease)
+        };
+
+        var actual = releasesIndex.GetLatestReleaseForChannel(Channel.Preview);
+        Assert.Equal(previewRelease, actual);
+    }
 }


### PR DESCRIPTION
There is a 'go-live' support phase that was not considered in the code. This will now be considered as part of the 'preview' channel.