### PR TITLE
Record channel for InstalledSdk in manifest

### DIFF
--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -33,16 +33,14 @@ public static class ListCommand
         logger.Log();
         var table = new Table();
         table.AddColumn(new TableColumn(" "));
-        table.AddColumn("Channel");
         table.AddColumn("Version");
+        table.AddColumn("Channel");
         table.AddColumn("Location");
-        foreach (var channel in manifest.TrackedChannels)
+        foreach (var sdk in manifest.InstalledSdkVersions)
         {
-            string selected = manifest.CurrentSdkDir == channel.SdkDirName ? "*" : " ";
-            foreach (var version in channel.InstalledSdkVersions)
-            {
-                table.AddRow(selected, channel.ChannelName.GetLowerName(), version.ToString(), channel.SdkDirName.Name);
-            }
+            string selected = manifest.CurrentSdkDir == sdk.SdkDirName ? "*" : " ";
+            var channel = sdk.Channel?.GetLowerName() ?? "";
+            table.AddRow(selected, sdk.Version.ToString(), channel, sdk.SdkDirName.Name);
         }
         logger.Console.Write(table);
     }

--- a/src/dnvm/Utilities/EqArray.cs
+++ b/src/dnvm/Utilities/EqArray.cs
@@ -50,6 +50,8 @@ public readonly struct EqArray<T>(ImmutableArray<T> value) : IReadOnlyCollection
         return ((IEnumerable)value).GetEnumerator();
     }
 
+    public T this[int index] => value[index];
+
     public EqArray<T> Add(T item) => new(value.Add(item));
 
     public EqArray<T> Replace(T oldItem, T newItem) => new(value.Replace(oldItem, newItem));

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -66,6 +66,24 @@ public static class Utilities
         return builder.MoveToImmutable();
     }
 
+    public static T? SingleOrNull<T>(this ImmutableArray<T> e, Func<T, bool> func)
+        where T : struct
+    {
+        T? result = null;
+        foreach (var elem in e)
+        {
+            if (func(elem))
+            {
+                if (result is not null)
+                {
+                    return null;
+                }
+                result = elem;
+            }
+        }
+        return result;
+    }
+
     public static readonly RID CurrentRID = new RID(
         GetCurrentOSPlatform(),
         RuntimeInformation.OSArchitecture,

--- a/src/dnvm/dnvm.csproj
+++ b/src/dnvm/dnvm.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="Semver" Version="2.2.0" />
 
-    <PackageReference Include="Serde" Version="0.5.2" />
+    <PackageReference Include="Serde" Version="0.5.3" />
 
     <PackageReference Include="Spectre.Console" Version="0.46.0" />
     <PackageReference Include="StaticCs" Version="0.2.0" />

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -21,22 +21,21 @@ public sealed class ListTests
     public void BasicList()
     {
         var manifest = Manifest.Empty
-            .AddSdk(new InstalledSdk(new(1,0,0)), Channel.Latest)
+            .AddSdk(new InstalledSdk(new(1,0,0)) { Channel = Channel.Latest }, Channel.Latest)
             .AddSdk(new InstalledSdk(SemVersion.Parse("4.0.0-preview1", SemVersionStyles.Strict))
-                    { SdkDirName = new("preview") },
+                    { SdkDirName = new("preview"), Channel = Channel.Preview },
                     Channel.Preview);
 
-        var newline = Text.NewLine;
         ListCommand.PrintSdks(_logger, manifest);
         var output = """
 Installed SDKs:
 
-┌───┬─────────┬────────────────┬──────────┐
-│   │ Channel │ Version        │ Location │
-├───┼─────────┼────────────────┼──────────┤
-│ * │ latest  │ 1.0.0          │ dn       │
-│   │ preview │ 4.0.0-preview1 │ preview  │
-└───┴─────────┴────────────────┴──────────┘
+┌───┬────────────────┬─────────┬──────────┐
+│   │ Version        │ Channel │ Location │
+├───┼────────────────┼─────────┼──────────┤
+│ * │ 1.0.0          │ latest  │ dn       │
+│   │ 4.0.0-preview1 │ preview │ preview  │
+└───┴────────────────┴─────────┴──────────┘
 """;
 
         Assert.Equal(output, string.Join(Environment.NewLine, _console.Lines));
@@ -46,7 +45,7 @@ Installed SDKs:
     public async Task ListFromFile()
     {
         var manifest = Manifest.Empty
-            .AddSdk(new InstalledSdk(new(42, 42, 42)), Channel.Latest);
+            .AddSdk(new InstalledSdk(new(42, 42, 42)) { Channel = Channel.Latest }, Channel.Latest);
 
         var env = new Dictionary<string, string>();
         using var userHome = new TempDirectory();
@@ -64,11 +63,11 @@ Installed SDKs:
         var output = """
 Installed SDKs:
 
-┌───┬─────────┬──────────┬──────────┐
-│   │ Channel │ Version  │ Location │
-├───┼─────────┼──────────┼──────────┤
-│ * │ latest  │ 42.42.42 │ dn       │
-└───┴─────────┴──────────┴──────────┘
+┌───┬──────────┬─────────┬──────────┐
+│   │ Version  │ Channel │ Location │
+├───┼──────────┼─────────┼──────────┤
+│ * │ 42.42.42 │ latest  │ dn       │
+└───┴──────────┴─────────┴──────────┘
 """;
 
         Assert.Equal(output, string.Join(Environment.NewLine, _console.Lines));

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -1,5 +1,6 @@
 
 using Dnvm;
+using Semver;
 using Xunit;
 
 public sealed class ManifestTests
@@ -18,5 +19,18 @@ public sealed class ManifestTests
 """;
         var parsed = ManifestUtils.DeserializeNewOrOldManifest(manifest)!;
         Assert.Equal("dn", parsed.CurrentSdkDir.Name);
+    }
+
+    [Fact]
+    public void ManifestV3Convert()
+    {
+        var v3 = ManifestV3.Empty
+            .AddSdk(new InstalledSdkV3("1.0.0"), Channel.Latest)
+            .AddSdk(new InstalledSdkV3("4.0.0-preview1")
+                    { SdkDirName = new("preview") },
+                    Channel.Preview);
+        var v4 = v3.Convert();
+        Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
+        Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
     }
 }


### PR DESCRIPTION
SDKs may be installed via tracking a channel. Since directories aren't strictly tied to channels, installation directory isn't a unique indicator of which channel it was installed from. This is useful information, and it may be required for later functionality.