### PR TITLE
Add more versions to the Manifest

### DIFF
--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -115,7 +115,7 @@ public sealed class DnvmEnv : IDisposable
     public async Task<Manifest> ReadManifest()
     {
         var text = Vfs.ReadAllText(ManifestPath);
-        return (await ManifestUtils.DeserializeNewOrOldManifest(text, DnvmReleasesUrl)) ?? throw new InvalidDataException();
+        return (await ManifestUtils.DeserializeNewOrOldManifest(text, DotnetFeedUrl)) ?? throw new InvalidDataException();
     }
 
     public void WriteManifest(Manifest manifest)

--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -112,10 +112,10 @@ public sealed class DnvmEnv : IDisposable
     /// an up-to-date <see cref="Manifest" /> (latest version).
     /// Throws <see cref="InvalidDataException" /> if the manifest is invalid.
     /// </summary>
-    public Manifest ReadManifest()
+    public async Task<Manifest> ReadManifest()
     {
         var text = Vfs.ReadAllText(ManifestPath);
-        return ManifestUtils.DeserializeNewOrOldManifest(text) ?? throw new InvalidDataException();
+        return (await ManifestUtils.DeserializeNewOrOldManifest(text, DnvmReleasesUrl)) ?? throw new InvalidDataException();
     }
 
     public void WriteManifest(Manifest manifest)

--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -15,7 +15,7 @@ public partial record DotnetReleasesIndex
     public const string ReleasesUrlSuffix = "/release-metadata/releases-index.json";
     public async static Task<DotnetReleasesIndex> FetchLatestIndex(string feed, string urlSuffix = ReleasesUrlSuffix)
     {
-        var response = await Program.HttpClient.GetStringAsync(feed + urlSuffix);
+        var response = await Program.HttpClient.GetStringAsync(feed.TrimEnd('/') + urlSuffix);
         return JsonSerializer.Deserialize<DotnetReleasesIndex>(response);
     }
 
@@ -104,7 +104,7 @@ public partial record ChannelReleaseIndex
         };
     }
 
-    public EqArray<Release> Releases { get; init; }
+    public required EqArray<Release> Releases { get; init; }
 
     [GenerateSerde]
     [SerdeTypeOptions(MemberFormat = MemberFormat.KebabCase)]

--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -99,6 +99,7 @@ public partial record ChannelReleaseIndex
             ReleaseVersion = universalVersion,
             Runtime = component,
             Sdk = component,
+            Sdks = [ component ],
             AspNetCore = component,
             WindowsDesktop = component
         };
@@ -114,6 +115,7 @@ public partial record ChannelReleaseIndex
         public required SemVersion ReleaseVersion { get; init; }
         public required Component Runtime { get; init; }
         public required Component Sdk { get; init; }
+        public required EqArray<Component> Sdks { get; init; }
         [SerdeMemberOptions(Rename = "aspnetcore-runtime")]
         public required Component AspNetCore { get; init; }
         [SerdeMemberOptions(Rename = "windowsdesktop")]

--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -18,7 +18,8 @@ public static class ListCommand
         }
         catch (Exception e)
         {
-            logger.Error("Error reading manifest: " + e.Message);
+            Environment.FailFast("Error reading manifest: ", e);
+            // unreachable
             return 1;
         }
 

--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -9,22 +9,22 @@ public static class ListCommand
 {
     /// <summary>
     /// Prints a list of installed SDK versions and their locations.
-    public static Task<int> Run(Logger logger, DnvmEnv home)
+    public static async Task<int> Run(Logger logger, DnvmEnv home)
     {
         Manifest manifest;
         try
         {
-            manifest = home.ReadManifest();
+            manifest = await home.ReadManifest();
         }
         catch (Exception e)
         {
             logger.Error("Error reading manifest: " + e.Message);
-            return Task.FromResult(1);
+            return 1;
         }
 
         PrintSdks(logger, manifest);
 
-        return Task.FromResult(0);
+        return 0;
     }
 
     public static void PrintSdks(Logger logger, Manifest manifest)
@@ -40,7 +40,7 @@ public static class ListCommand
         {
             string selected = manifest.CurrentSdkDir == sdk.SdkDirName ? "*" : " ";
             var channel = sdk.Channel?.GetLowerName() ?? "";
-            table.AddRow(selected, sdk.Version.ToString(), channel, sdk.SdkDirName.Name);
+            table.AddRow(selected, sdk.SdkVersion.ToString(), channel, sdk.SdkDirName.Name);
         }
         logger.Console.Write(table);
     }

--- a/src/dnvm/ManifestSchema/Manifest.cs
+++ b/src/dnvm/ManifestSchema/Manifest.cs
@@ -81,7 +81,7 @@ public static partial class ManifestConvert
                 return channelReleaseIndex;
             }
 
-            var channelRelease = releasesIndex.Releases.Single(r => r.MajorMinorVersion == majorMinor.ToString());
+            var channelRelease = releasesIndex.Releases.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
             channelReleaseIndex = JsonSerializer.Deserialize<ChannelReleaseIndex>(
                 await Program.HttpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
             channelMemo[majorMinor] = channelReleaseIndex;

--- a/src/dnvm/ManifestSchema/ManifestV4.cs
+++ b/src/dnvm/ManifestSchema/ManifestV4.cs
@@ -1,0 +1,158 @@
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Serde;
+using Serde.Json;
+using StaticCs;
+using StaticCs.Collections;
+
+namespace Dnvm;
+
+[GenerateSerde]
+public sealed partial record ManifestV4
+{
+    public static readonly ManifestV4 Empty = new();
+
+    // Serde doesn't serialize consts, so we have a separate property below for serialization.
+    public const int VersionField = 4;
+
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public int Version => VersionField;
+
+    public SdkDirName CurrentSdkDir { get; init; } = DnvmEnv.DefaultSdkDirName;
+    public ImmutableArray<InstalledSdkV4> InstalledSdkVersions { get; init; } = ImmutableArray<InstalledSdkV4>.Empty;
+    public ImmutableArray<TrackedChannelV4> TrackedChannels { get; init; } = ImmutableArray<TrackedChannelV4>.Empty;
+
+    public override string ToString()
+    {
+        return $"ManifestV4 {{ Version = {Version}, "
+            + $"InstalledSdkV4Version = [{InstalledSdkVersions.SeqToString()}, "
+            + $"TrackedChannelV4s = [{TrackedChannels.SeqToString()}] }}";
+    }
+
+    public bool Equals(ManifestV4? other)
+    {
+        return other is not null && InstalledSdkVersions.SequenceEqual(other.InstalledSdkVersions) &&
+            TrackedChannels.SequenceEqual(other.TrackedChannels);
+    }
+
+    public override int GetHashCode()
+    {
+        int code = 0;
+        foreach (var item in InstalledSdkVersions)
+        {
+            code = HashCode.Combine(code, item);
+        }
+        foreach (var item in TrackedChannels)
+        {
+            code = HashCode.Combine(code, item);
+        }
+        return code;
+    }
+
+    internal ManifestV4 Untrack(Channel channel)
+    {
+        return this with
+        {
+            TrackedChannels = TrackedChannels.Where(c => c.ChannelName != channel).ToImmutableArray()
+        };
+    }
+}
+
+[GenerateSerde]
+public readonly partial record struct TrackedChannelV4()
+{
+    public required Channel ChannelName { get; init; }
+    public required SdkDirName SdkDirName { get; init; }
+    public ImmutableArray<string> InstalledSdkVersions { get; init; } = ImmutableArray<string>.Empty;
+
+    public bool Equals(TrackedChannelV4 other)
+    {
+        return ChannelName == other.ChannelName &&
+            SdkDirName == other.SdkDirName &&
+            InstalledSdkVersions.SequenceEqual(other.InstalledSdkVersions);
+    }
+
+    public override int GetHashCode()
+    {
+        int code = 0;
+        code = HashCode.Combine(code, ChannelName);
+        code = HashCode.Combine(code, SdkDirName);
+        foreach (string item in InstalledSdkVersions)
+        {
+            code = HashCode.Combine(code, item);
+        }
+        return code;
+    }
+}
+
+[GenerateSerde]
+public readonly partial record struct InstalledSdkV4(string Version)
+{
+    public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
+}
+
+public static partial class ManifestV4Convert
+{
+    public static ManifestV4 Convert(this ManifestV3 v3)
+    {
+        return new ManifestV4
+        {
+            InstalledSdkVersions = v3.InstalledSdkVersions.SelectAsArray(v => v.Convert()),
+            TrackedChannels = v3.TrackedChannels.SelectAsArray(c => c.Convert()),
+        };
+    }
+
+    public static InstalledSdkV4 Convert(this InstalledSdkV3 v3)
+    {
+        return new InstalledSdkV4 {
+            SdkDirName = v3.SdkDirName,
+            Version = v3.Version,
+        };
+    }
+
+    public static TrackedChannelV4 Convert(this TrackedChannelV3 v3) => new TrackedChannelV4 {
+        ChannelName = v3.ChannelName,
+        SdkDirName = v3.SdkDirName,
+        InstalledSdkVersions = v3.InstalledSdkVersions,
+    };
+}
+
+public static partial class ManifestV4Utils
+{
+    public static ManifestV4 AddSdk(this ManifestV4 manifest, InstalledSdkV4 sdk, Channel c)
+    {
+        ManifestV4 newManifest;
+        if (manifest.TrackedChannels.FirstOrNull(x => x.ChannelName == c) is { } trackedChannel)
+        {
+            if (trackedChannel.InstalledSdkVersions.Contains(sdk.Version))
+            {
+                return manifest;
+            }
+            newManifest = manifest with
+            {
+                TrackedChannels = manifest.TrackedChannels.Select(x => x.ChannelName == c
+                    ? x with { InstalledSdkVersions = x.InstalledSdkVersions.Add(sdk.Version) }
+                    : x).ToImmutableArray(),
+                InstalledSdkVersions = manifest.InstalledSdkVersions.Add(sdk)
+            };
+        }
+        else
+        {
+            newManifest = manifest with
+            {
+                TrackedChannels = manifest.TrackedChannels.Add(new TrackedChannelV4()
+                {
+                    ChannelName = c,
+                    SdkDirName = sdk.SdkDirName,
+                    InstalledSdkVersions = ImmutableArray.Create(sdk.Version)
+                }),
+                InstalledSdkVersions = manifest.InstalledSdkVersions.Add(sdk)
+            };
+        }
+        return newManifest;
+    }
+}

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -121,9 +121,10 @@ public static partial class ManifestUtils
             return version switch
             {
                 // The first version didn't have a version field
-                null => await JsonSerializer.Deserialize<ManifestV1>(manifestSrc).Convert().Convert().Convert(releasesIndex),
-                ManifestV2.VersionField => await JsonSerializer.Deserialize<ManifestV2>(manifestSrc).Convert().Convert(releasesIndex),
-                ManifestV3.VersionField => await JsonSerializer.Deserialize<ManifestV3>(manifestSrc).Convert(releasesIndex),
+                null => await JsonSerializer.Deserialize<ManifestV1>(manifestSrc).Convert().Convert().Convert().Convert(releasesIndex),
+                ManifestV2.VersionField => await JsonSerializer.Deserialize<ManifestV2>(manifestSrc).Convert().Convert().Convert(releasesIndex),
+                ManifestV3.VersionField => await JsonSerializer.Deserialize<ManifestV3>(manifestSrc).Convert().Convert(releasesIndex),
+                ManifestV4.VersionField => await JsonSerializer.Deserialize<ManifestV4>(manifestSrc).Convert(releasesIndex),
                 _ => null,
             };
         }

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Serde;
 using Serde.Json;
 using StaticCs;
@@ -58,22 +59,11 @@ public static class Channels
 
 public static partial class ManifestUtils
 {
-    /// <summary>
-    /// Reads a manifest (any version) from the given path and returns
-    /// an up-to-date <see cref="Manifest" /> (latest version).
-    /// Throws <see cref="InvalidDataException" /> if the manifest is invalid.
-    /// </summary>
-    public static Manifest ReadManifest(string manifestPath)
-    {
-        string text = File.ReadAllText(manifestPath);
-        return DeserializeNewOrOldManifest(text) ?? throw new InvalidDataException();
-    }
-
-    public static Manifest ReadOrCreateManifest(DnvmEnv fs)
+    public static async Task<Manifest> ReadOrCreateManifest(DnvmEnv fs)
     {
         try
         {
-            return fs.ReadManifest();
+            return await fs.ReadManifest();
         }
         // Not found is expected
         catch (Exception e) when (e is DirectoryNotFoundException or FileNotFoundException) { }
@@ -81,40 +71,19 @@ public static partial class ManifestUtils
         return Manifest.Empty;
     }
 
-    /// <summary>
-    /// Tries to read or create a manifest from the given path. If an IO exception other than <see
-    /// cref="DirectoryNotFoundException" /> or <see cref="FileNotFoundException" /> occurs, it will
-    /// be rethrown. Throws <see cref="InvalidDataException" />.
-    /// </summary>
-    public static Manifest ReadOrCreateManifest(string manifestPath)
-    {
-        try
-        {
-            return ReadManifest(manifestPath);
-        }
-        // Not found is expected
-        catch (Exception e) when (e is DirectoryNotFoundException or FileNotFoundException) { }
-
-        return new Manifest()
-        {
-            InstalledSdkVersions = [],
-            TrackedChannels = []
-        };
-    }
-
     public static Manifest AddSdk(this Manifest manifest, InstalledSdk sdk, Channel c)
     {
         Manifest newManifest;
         if (manifest.TrackedChannels.FirstOrNull(x => x.ChannelName == c) is { } trackedChannel)
         {
-            if (trackedChannel.InstalledSdkVersions.Contains(sdk.Version))
+            if (trackedChannel.InstalledSdkVersions.Contains(sdk.SdkVersion))
             {
                 return manifest;
             }
             newManifest = manifest with
             {
                 TrackedChannels = manifest.TrackedChannels.Select(x => x.ChannelName == c
-                    ? x with { InstalledSdkVersions = x.InstalledSdkVersions.Add(sdk.Version) }
+                    ? x with { InstalledSdkVersions = x.InstalledSdkVersions.Add(sdk.SdkVersion) }
                     : x).ToEq(),
                 InstalledSdkVersions = manifest.InstalledSdkVersions.Add(sdk)
             };
@@ -127,7 +96,7 @@ public static partial class ManifestUtils
                 {
                     ChannelName = c,
                     SdkDirName = sdk.SdkDirName,
-                    InstalledSdkVersions = ImmutableArray.Create(sdk.Version).ToEq()
+                    InstalledSdkVersions = [ sdk.SdkVersion ]
                 }),
                 InstalledSdkVersions = manifest.InstalledSdkVersions.Add(sdk)
             };
@@ -139,18 +108,22 @@ public static partial class ManifestUtils
     /// Either reads a manifest in the current format, or reads a
     /// manifest in the old format and converts it to the new format.
     /// </summary>
-    public static Manifest? DeserializeNewOrOldManifest(string manifestSrc)
+    public static async Task<Manifest?> DeserializeNewOrOldManifest(string manifestSrc, string releasesUrl)
     {
         try
         {
             var version = JsonSerializer.Deserialize<ManifestVersionOnly>(manifestSrc).Version;
+            if (version is Manifest.VersionField)
+            {
+                return JsonSerializer.Deserialize<Manifest>(manifestSrc);
+            }
+            var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(releasesUrl);
             return version switch
             {
                 // The first version didn't have a version field
-                null => JsonSerializer.Deserialize<ManifestV1>(manifestSrc).Convert().Convert().Convert(),
-                ManifestV2.VersionField => JsonSerializer.Deserialize<ManifestV2>(manifestSrc).Convert().Convert(),
-                ManifestV3.VersionField => JsonSerializer.Deserialize<ManifestV3>(manifestSrc).Convert(),
-                Manifest.VersionField => JsonSerializer.Deserialize<Manifest>(manifestSrc),
+                null => await JsonSerializer.Deserialize<ManifestV1>(manifestSrc).Convert().Convert().Convert(releasesIndex),
+                ManifestV2.VersionField => await JsonSerializer.Deserialize<ManifestV2>(manifestSrc).Convert().Convert(releasesIndex),
+                ManifestV3.VersionField => await JsonSerializer.Deserialize<ManifestV3>(manifestSrc).Convert(releasesIndex),
                 _ => null,
             };
         }

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -41,7 +41,7 @@ public static class Program
             CommandArguments.UpdateArguments o => (int)await UpdateCommand.Run(env, logger, o),
             CommandArguments.ListArguments => (int)await ListCommand.Run(logger, env),
             CommandArguments.SelectArguments o => (int)await SelectCommand.Run(env, logger, o),
-            CommandArguments.UntrackArguments o => UntrackCommand.Run(env, logger, o),
+            CommandArguments.UntrackArguments o => await UntrackCommand.Run(env, logger, o),
             _ => throw ExceptionUtilities.Unreachable
         };
     }

--- a/src/dnvm/SelectCommand.cs
+++ b/src/dnvm/SelectCommand.cs
@@ -20,7 +20,7 @@ public static class SelectCommand
     public static async Task<Result> Run(DnvmEnv dnvmEnv, Logger logger, CommandArguments.SelectArguments args)
     {
         var newDir = new SdkDirName(args.SdkDirName);
-        var manifest = dnvmEnv.ReadManifest();
+        var manifest = await dnvmEnv.ReadManifest();
         switch (await RunWithManifest(dnvmEnv, newDir, manifest, logger))
         {
             case Result<Manifest, Result>.Ok(var newManifest):

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -188,7 +188,7 @@ public class SelfInstallCommand
         SdkDirName sdkDirName;
         try
         {
-            var manifest = dnvmEnv.ReadManifest();
+            var manifest = await dnvmEnv.ReadManifest();
             sdkDirName = manifest.CurrentSdkDir;
         }
         catch

--- a/src/dnvm/UntrackCommand.cs
+++ b/src/dnvm/UntrackCommand.cs
@@ -17,12 +17,12 @@ public sealed class UntrackCommand
         public record ManifestReadError : Result;
     }
 
-    public static int Run(DnvmEnv env, Logger logger, CommandArguments.UntrackArguments options)
+    public static async Task<int> Run(DnvmEnv env, Logger logger, CommandArguments.UntrackArguments options)
     {
         Manifest manifest;
         try
         {
-            manifest = env.ReadManifest();
+            manifest = await env.ReadManifest();
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {

--- a/src/dnvm/Utilities/EqArray.cs
+++ b/src/dnvm/Utilities/EqArray.cs
@@ -68,7 +68,7 @@ public static class EqArraySerdeWrap
         }
     }
     public readonly record struct DeserializeImpl<T, TWrap> : IDeserialize<EqArray<T>>
-        where TWrap : struct, IDeserialize<T>
+        where TWrap : IDeserialize<T>
     {
         static EqArray<T> IDeserialize<EqArray<T>>.Deserialize<D>(ref D deserializer)
         {

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using Semver;
 using StaticCs;
 using Zio;
 using Zio.FileSystems;
@@ -51,6 +52,8 @@ public static class Utilities
         File.SetUnixFileMode(realPath, mod | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
     }
 
+    public static string ToMajorMinor(this SemVersion version) => $"{version.Major}.{version.Minor}";
+
     public static string SeqToString<T>(this IEnumerable<T> e)
     {
         return "[ " + string.Join(", ", e.ToString()) + " ]";
@@ -62,6 +65,16 @@ public static class Utilities
         foreach (var item in e)
         {
             builder.Add(f(item));
+        }
+        return builder.MoveToImmutable();
+    }
+
+    public static async Task<ImmutableArray<U>> SelectAsArray<T, U>(this ImmutableArray<T> e, Func<T, Task<U>> f)
+    {
+        var builder = ImmutableArray.CreateBuilder<U>(e.Length);
+        foreach (var item in e)
+        {
+            builder.Add(await f(item));
         }
         return builder.MoveToImmutable();
     }

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -1,5 +1,6 @@
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
 using Semver;
@@ -63,6 +64,7 @@ public sealed class MockServer : IAsyncDisposable
         };
     }
 
+    [MemberNotNull(nameof(ReleasesIndexJson))]
     private void RegisterReleaseVersion(SemVersion ltsVersion, string releaseType, string supportPhase)
     {
         var majorMinor = ltsVersion.ToMajorMinor();

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Net;
 using System.Text;
+using Semver;
 using Serde.Json;
 using static Dnvm.Utilities;
 
@@ -18,27 +19,14 @@ public sealed class MockServer : IAsyncDisposable
     public string DnvmReleasesUrl => PrefixString + "releases.json";
     public string? DnvmPath { get; set; } = null;
 
-    public DotnetReleasesIndex ReleasesIndexJson { get; set; } = new DotnetReleasesIndex
-    {
-        Releases = ImmutableArray.Create(new DotnetReleasesIndex.Release[] {
-            new() {
-                LatestRelease = "42.42.42",
-                LatestSdk = "42.42.142",
-                MajorMinorVersion = "42.42",
-                ReleaseType = "lts",
-                SupportPhase = "active"
-            },
-            new() {
-                LatestRelease = "99.99.99-preview",
-                LatestSdk = "99.99.99-preview",
-                MajorMinorVersion = "99.99",
-                ReleaseType = "sts",
-                SupportPhase = "preview"
-            }
-        })
-    };
+    public DotnetReleasesIndex ReleasesIndexJson { get; set; }
 
     public DnvmReleases DnvmReleases { get; set; }
+
+    public Dictionary<string, ChannelReleaseIndex> ChannelIndexMap { get; } = new();
+
+    private string GetChannelIndexPath(string majorMinor) => $"release-metadata/{majorMinor}/index.json";
+    public string GetChannelIndexUrl(string majorMinor) => PrefixString + GetChannelIndexPath(majorMinor);
 
     public MockServer(TaskScope scope)
     {
@@ -59,6 +47,8 @@ public sealed class MockServer : IAsyncDisposable
             {
             }
         }
+        RegisterReleaseVersion(new SemVersion(42, 42, 42), "lts", "active");
+        RegisterReleaseVersion(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), "sts", "preview");
         DnvmReleases = new()
         {
             LatestVersion = new()
@@ -71,6 +61,30 @@ public sealed class MockServer : IAsyncDisposable
                 }
             }
         };
+    }
+
+    private void RegisterReleaseVersion(SemVersion ltsVersion, string releaseType, string supportPhase)
+    {
+        var majorMinor = ltsVersion.ToMajorMinor();
+        ReleasesIndexJson ??= new DotnetReleasesIndex{ Releases = [ ] };
+        ReleasesIndexJson = ReleasesIndexJson with {
+            Releases = ReleasesIndexJson.Releases.Add(new() {
+                LatestRelease = ltsVersion.ToString(),
+                LatestSdk = ltsVersion.ToString(),
+                MajorMinorVersion = majorMinor,
+                ReleaseType = releaseType,
+                SupportPhase = supportPhase,
+                ChannelReleaseIndexUrl = GetChannelIndexUrl(majorMinor)
+            })
+        };
+        if (!ChannelIndexMap.TryGetValue(majorMinor, out var index))
+        {
+            index = new() { Releases = [] };
+        }
+        index = index with {
+            Releases = index.Releases.Add(ChannelReleaseIndex.CreateRelease(ltsVersion))
+        };
+        ChannelIndexMap[majorMinor] = index;
     }
 
     private async Task WaitForConnection()
@@ -108,6 +122,10 @@ public sealed class MockServer : IAsyncDisposable
                 ["/releases.json"] = GetReleasesJson,
                 [$"/dnvm/dnvm{ZipSuffix}"] = GetDnvm,
             };
+            foreach (var (version, index) in ChannelIndexMap)
+            {
+                routes["/" + GetChannelIndexPath(version)] = GetChannelIndexJson(index);
+            }
             foreach (var r in ReleasesIndexJson.Releases)
             {
                 routes[$"/sdk/{r.LatestSdk}/dotnet-sdk-{r.LatestSdk}-{CurrentRID}{ZipSuffix}"] = GetSdk;
@@ -126,6 +144,19 @@ public sealed class MockServer : IAsyncDisposable
         output.Write(buffer, 0, buffer.Length);
         // You must close the output stream.
         output.Close();
+    }
+
+    private Action<HttpListenerResponse> GetChannelIndexJson(ChannelReleaseIndex index)
+    {
+        var buffer = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(index));
+        return (response) =>
+        {
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentLength64 = buffer.Length;
+            var output = response.OutputStream;
+            output.Write(buffer, 0, buffer.Length);
+            output.Close();
+        };
     }
 
     private static void GetSdk(HttpListenerResponse response)

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -31,10 +31,14 @@ public sealed class InstallTests
         Assert.True(env.Vfs.FileExists(dotnetFile));
         Assert.Contains(Assets.ArchiveToken, env.Vfs.ReadAllText(dotnetFile));
 
-        var manifest = env.ReadManifest();
+        var manifest = await env.ReadManifest();
         var installedVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[0].LatestSdk, SemVersionStyles.Strict);
         EqArray<InstalledSdk> installedVersions = [ new InstalledSdk {
-            Version = installedVersion,
+            SdkVersion = installedVersion,
+            AspNetVersion = installedVersion,
+            RuntimeVersion = installedVersion,
+            ReleaseVersion = installedVersion,
+            Channel = channel,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ];
         Assert.Equal(new Manifest
@@ -42,10 +46,10 @@ public sealed class InstallTests
             InstalledSdkVersions = installedVersions,
             TrackedChannels = [
                 new TrackedChannel {
-                        ChannelName = channel,
-                        SdkDirName = DnvmEnv.DefaultSdkDirName,
-                        InstalledSdkVersions = [ installedVersion ]
-                    },
+                    ChannelName = channel,
+                    SdkDirName = DnvmEnv.DefaultSdkDirName,
+                    InstalledSdkVersions = [ installedVersion ]
+                },
             ]
         }, manifest);
     });

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -20,11 +20,21 @@ public sealed class ListTests
     [Fact]
     public void BasicList()
     {
+        var previewVersion = SemVersion.Parse("4.0.0-preview1", SemVersionStyles.Strict);
         var manifest = Manifest.Empty
-            .AddSdk(new InstalledSdk(new(1,0,0)) { Channel = Channel.Latest }, Channel.Latest)
-            .AddSdk(new InstalledSdk(SemVersion.Parse("4.0.0-preview1", SemVersionStyles.Strict))
-                    { SdkDirName = new("preview"), Channel = Channel.Preview },
-                    Channel.Preview);
+            .AddSdk(new InstalledSdk() {
+                SdkVersion = new(1,0,0),
+                RuntimeVersion = new(1,0,0),
+                AspNetVersion = new(1,0,0),
+                ReleaseVersion = new(1,0,0),
+                Channel = Channel.Latest }, Channel.Latest)
+            .AddSdk(new InstalledSdk() {
+                SdkVersion = previewVersion,
+                RuntimeVersion = previewVersion,
+                AspNetVersion = previewVersion,
+                ReleaseVersion = previewVersion,
+                SdkDirName = new("preview"),
+                Channel = Channel.Preview }, Channel.Preview);
 
         ListCommand.PrintSdks(_logger, manifest);
         var output = """
@@ -45,7 +55,13 @@ Installed SDKs:
     public async Task ListFromFile()
     {
         var manifest = Manifest.Empty
-            .AddSdk(new InstalledSdk(new(42, 42, 42)) { Channel = Channel.Latest }, Channel.Latest);
+            .AddSdk(new InstalledSdk() {
+                SdkVersion = new(42, 42, 42),
+                RuntimeVersion = new(42, 42, 42),
+                AspNetVersion = new(42, 42, 42),
+                ReleaseVersion = new(42, 42, 42),
+                Channel = Channel.Latest
+            }, Channel.Latest);
 
         var env = new Dictionary<string, string>();
         using var userHome = new TempDirectory();

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -30,7 +30,7 @@ public sealed class ManifestTests
             .AddSdk(new InstalledSdkV3("4.0.0-preview1")
                     { SdkDirName = new("preview") },
                     Channel.Preview);
-        var v4 = await v3.Convert(server.ReleasesIndexJson);
+        var v4 = await v3.Convert().Convert(server.ReleasesIndexJson);
         Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
         Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
     });

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 public sealed class ManifestTests
 {
     [Fact]
-    public void MissingCurrentSdkDir()
+    public async Task MissingCurrentSdkDir()
     {
         var manifest = """
 {
@@ -17,8 +17,8 @@ public sealed class ManifestTests
     ]
 }
 """;
-        var parsed = ManifestUtils.DeserializeNewOrOldManifest(manifest)!;
-        Assert.Equal("dn", parsed.CurrentSdkDir.Name);
+   //     var parsed = await ManifestUtils.DeserializeNewOrOldManifest(manifest)!;
+   //     Assert.Equal("dn", parsed.CurrentSdkDir.Name);
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public sealed class ManifestTests
             .AddSdk(new InstalledSdkV3("4.0.0-preview1")
                     { SdkDirName = new("preview") },
                     Channel.Preview);
-        var v4 = v3.Convert();
-        Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
-        Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
+        //var v4 = v3.Convert();
+        //Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
+        //Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
     }
 }

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -1,36 +1,37 @@
 
 using Dnvm;
+using Dnvm.Test;
 using Semver;
 using Xunit;
 
 public sealed class ManifestTests
 {
     [Fact]
-    public async Task MissingCurrentSdkDir()
+    public Task MissingCurrentSdkDir() => TestUtils.RunWithServer(async (server, env) =>
     {
         var manifest = """
 {
     "version":3,
-    "installedSdkVersions":[{"version":"7.0.102","sdkDirName":{"name":"dn"}}],
+    "installedSdkVersions":[{"version":"42.42.42","sdkDirName":{"name":"dn"}}],
     "trackedChannels":[
-        {"channelName":"latest","sdkDirName":{"name":"dn"},"installedSdkVersions":["7.0.102"]}
+        {"channelName":"latest","sdkDirName":{"name":"dn"},"installedSdkVersions":["42.42.42"]}
     ]
 }
 """;
-   //     var parsed = await ManifestUtils.DeserializeNewOrOldManifest(manifest)!;
-   //     Assert.Equal("dn", parsed.CurrentSdkDir.Name);
-    }
+        var parsed = await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrl);
+        Assert.Equal("dn", parsed!.CurrentSdkDir.Name);
+    });
 
     [Fact]
-    public void ManifestV3Convert()
+    public void ManifestV3Convert() => TestUtils.RunWithServer(async server =>
     {
         var v3 = ManifestV3.Empty
             .AddSdk(new InstalledSdkV3("1.0.0"), Channel.Latest)
             .AddSdk(new InstalledSdkV3("4.0.0-preview1")
                     { SdkDirName = new("preview") },
                     Channel.Preview);
-        //var v4 = v3.Convert();
-        //Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
-        //Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
-    }
+        var v4 = await v3.Convert(server.ReleasesIndexJson);
+        Assert.Equal(Channel.Latest, v4.InstalledSdkVersions[0].Channel);
+        Assert.Equal(Channel.Preview, v4.InstalledSdkVersions[1].Channel);
+    });
 }

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -43,7 +43,7 @@ public sealed class SelectTests
         AssertSymlinkTarget(dotnetSymlink, defaultSdkDir);
 
         // Select the preview SDK
-        var manifest = env.ReadManifest();
+        var manifest = await env.ReadManifest();
         Assert.Equal(DnvmEnv.DefaultSdkDirName, manifest.CurrentSdkDir);
 
         var previewSdkDir = new SdkDirName("preview");


### PR DESCRIPTION
In order to implement uninstall, we need versions for each of the components that make up an SDK. Those versions were not previously stored in the manifest, and not available from the APIs we were calling. This PR changes the manifest to contain these versions and adds support for pulling more detailed information from the index.