### PR TITLE
Rename 'install' to 'track' and add 'uninstall'

### DIFF
--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Semver;
 using Serde;
 using Serde.Json;
 using StaticCs;
@@ -69,6 +70,19 @@ public static partial class ManifestUtils
         catch (Exception e) when (e is DirectoryNotFoundException or FileNotFoundException) { }
 
         return Manifest.Empty;
+    }
+
+    public static Manifest AddSdk(this Manifest manifest, SemVersion semVersion, Channel c, SdkDirName sdkDirName)
+    {
+        var installedSdk = new InstalledSdk() {
+            Channel = c,
+            SdkDirName = sdkDirName,
+            SdkVersion = semVersion,
+            RuntimeVersion = semVersion,
+            AspNetVersion = semVersion,
+            ReleaseVersion = semVersion,
+        };
+        return manifest.AddSdk(installedSdk, c);
     }
 
     public static Manifest AddSdk(this Manifest manifest, InstalledSdk sdk, Channel c)

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -42,6 +42,7 @@ public static class Program
             CommandArguments.ListArguments => (int)await ListCommand.Run(logger, env),
             CommandArguments.SelectArguments o => (int)await SelectCommand.Run(env, logger, o),
             CommandArguments.UntrackArguments o => await UntrackCommand.Run(env, logger, o),
+            CommandArguments.UninstallArguments o => await UninstallCommand.Run(env, logger, o),
             _ => throw ExceptionUtilities.Unreachable
         };
     }

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -1,0 +1,130 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Semver;
+using Zio;
+
+namespace Dnvm;
+
+public sealed class UninstallCommand
+{
+    public static async Task<int> Run(DnvmEnv env, Logger logger, CommandArguments.UninstallArguments args)
+    {
+        Manifest manifest;
+        try
+        {
+            manifest = await env.ReadManifest();
+        }
+        catch (Exception e)
+        {
+            Environment.FailFast("Error reading manifest: ", e);
+            // unreachable
+            return 1;
+        }
+
+        var runtimesToKeep = new HashSet<(SemVersion, SdkDirName)>();
+        var runtimesToRemove = new HashSet<(SemVersion, SdkDirName)>();
+        var sdksToRemove = new HashSet<(SemVersion, SdkDirName)>();
+        var aspnetToKeep = new HashSet<(SemVersion, SdkDirName)>();
+        var aspnetToRemove = new HashSet<(SemVersion, SdkDirName)>();
+        var winToKeep = new HashSet<(SemVersion, SdkDirName)>();
+        var winToRemove = new HashSet<(SemVersion, SdkDirName)>();
+
+        foreach (var installed in manifest.InstalledSdkVersions)
+        {
+            if (installed.SdkVersion == args.SdkVersion)
+            {
+                sdksToRemove.Add((installed.SdkVersion, installed.SdkDirName));
+                runtimesToRemove.Add((installed.RuntimeVersion, installed.SdkDirName));
+                aspnetToRemove.Add((installed.AspNetVersion, installed.SdkDirName));
+                winToRemove.Add((installed.ReleaseVersion, installed.SdkDirName));
+            }
+            else
+            {
+                runtimesToKeep.Add((installed.RuntimeVersion, installed.SdkDirName));
+                aspnetToKeep.Add((installed.AspNetVersion, installed.SdkDirName));
+                winToKeep.Add((installed.ReleaseVersion, installed.SdkDirName));
+            }
+        }
+
+        runtimesToRemove.ExceptWith(runtimesToKeep);
+        aspnetToRemove.ExceptWith(aspnetToKeep);
+        winToRemove.ExceptWith(winToKeep);
+
+        DeleteSdks(env, sdksToRemove);
+        DeleteRuntimes(env, runtimesToRemove);
+        DeleteAspnets(env, aspnetToRemove);
+        DeleteWins(env, winToRemove);
+
+        manifest = UninstallSdk(manifest, args.SdkVersion);
+        env.WriteManifest(manifest);
+
+        return 0;
+    }
+
+    private static void DeleteSdks(DnvmEnv env, IEnumerable<(SemVersion, SdkDirName)> sdks)
+    {
+        foreach (var (version, dir) in sdks)
+        {
+            var verString = version.ToString();
+            var sdkDir = DnvmEnv.GetSdkPath(dir) / "sdk" / verString;
+
+            env.Vfs.DeleteDirectory(sdkDir, isRecursive: true);
+        }
+    }
+
+    private static void DeleteRuntimes(DnvmEnv env, IEnumerable<(SemVersion, SdkDirName)> runtimes)
+    {
+        foreach (var (version, dir) in runtimes)
+        {
+            var verString = version.ToString();
+            var netcoreappDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.NETCore.App" / verString;
+            var hostfxrDir = DnvmEnv.GetSdkPath(dir) / "host" / "fxr" / verString;
+            var packsHostDir = DnvmEnv.GetSdkPath(dir) / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / verString;
+
+            env.Vfs.DeleteDirectory(netcoreappDir, isRecursive: true);
+            env.Vfs.DeleteDirectory(hostfxrDir, isRecursive: true);
+            env.Vfs.DeleteDirectory(packsHostDir, isRecursive: true);
+        }
+    }
+
+    private static void DeleteAspnets(DnvmEnv env, IEnumerable<(SemVersion, SdkDirName)> aspnets)
+    {
+        foreach (var (version, dir) in aspnets)
+        {
+            var verString = version.ToString();
+            var aspnetDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.AspNetCore.App" / verString;
+            var templatesDir = DnvmEnv.GetSdkPath(dir) / "templates" / verString;
+
+            env.Vfs.DeleteDirectory(aspnetDir, isRecursive: true);
+            env.Vfs.DeleteDirectory(templatesDir, isRecursive: true);
+        }
+    }
+
+    private static void DeleteWins(DnvmEnv env, IEnumerable<(SemVersion, SdkDirName)> wins)
+    {
+        foreach (var (version, dir) in wins)
+        {
+            var verString = version.ToString();
+            var winDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.WindowsDesktop.App" / verString;
+
+            if (env.Vfs.DirectoryExists(winDir))
+            {
+                env.Vfs.DeleteDirectory(winDir, isRecursive: true);
+            }
+        }
+    }
+
+    private static Manifest UninstallSdk(Manifest manifest, SemVersion sdkVersion)
+    {
+        // Delete SDK version from all directories
+        var newVersions = manifest.InstalledSdkVersions
+            .Where(sdk => sdk.SdkVersion != sdkVersion)
+            .ToEq();
+        return manifest with {
+            InstalledSdkVersions = newVersions,
+        };
+    }
+}

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -56,7 +56,7 @@ public static class Utilities
 
     public static string SeqToString<T>(this IEnumerable<T> e)
     {
-        return "[ " + string.Join(", ", e.ToString()) + " ]";
+        return "[ " + string.Join(", ", e) + " ]";
     }
 
     public static ImmutableArray<U> SelectAsArray<T, U>(this ImmutableArray<T> e, Func<T, U> f)

--- a/test/Shared/Dnvm.Test.Shared.csproj
+++ b/test/Shared/Dnvm.Test.Shared.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="staticcs.async" Version="0.1.1" />
+    <PackageReference Include="staticcs.async" Version="0.1.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -1,0 +1,58 @@
+
+using Semver;
+using Spectre.Console.Testing;
+using Xunit;
+using Zio;
+using static Dnvm.Test.TestUtils;
+
+namespace Dnvm.Test;
+
+public sealed class UninstallTests
+{
+    private readonly Logger _logger = new Logger(new TestConsole());
+
+    [Fact]
+    public Task LtsAndPreview() => RunWithServer(async (server, env) =>
+    {
+        var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        {
+            Channel = Channel.Latest,
+        });
+        Assert.Equal(TrackCommand.Result.Success, result);
+        result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        {
+            Channel = Channel.Preview,
+        });
+        Assert.Equal(TrackCommand.Result.Success, result);
+        var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[0].LatestSdk, SemVersionStyles.Strict);
+        var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[1].LatestSdk, SemVersionStyles.Strict);
+        var expectedManifest = Manifest.Empty
+            .AddSdk(ltsVersion, Channel.Latest, DnvmEnv.DefaultSdkDirName)
+            .AddSdk(previewVersion, Channel.Preview, new SdkDirName("preview"));
+        var manifest = await env.ReadManifest();
+        Assert.Equal(expectedManifest, manifest);
+        var unResult = await UninstallCommand.Run(env, _logger, new CommandArguments.UninstallArguments
+        {
+            SdkVersion = ltsVersion
+        });
+        Assert.Equal(0, unResult);
+        manifest = await env.ReadManifest();
+        var previewOnly = Manifest.Empty
+            .AddSdk(previewVersion, Channel.Preview, new SdkDirName("preview"));
+        previewOnly = previewOnly with {
+            TrackedChannels = manifest.TrackedChannels
+        };
+        Assert.Equal(previewOnly, manifest);
+
+        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.NETCore.App" / ltsVersion.ToString()));
+        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
+        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
+        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "host" / "fxr" / ltsVersion.ToString()));
+
+        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.NETCore.App" / previewVersion.ToString()));
+        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.AspNetCore.App" / previewVersion.ToString()));
+        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "host" / "fxr" / previewVersion.ToString()));
+        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / previewVersion.ToString()));
+        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "templates" / previewVersion.ToString()));
+    });
+}


### PR DESCRIPTION
The 'dnvm install' command mostly starts tracking a channel, and only incidentally installs an SDK.

Also adds an uninstall command that can remove a particular SDK.