### PR TITLE
Install preview SDKs to the default folder

### DIFF
--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -16,7 +16,10 @@ namespace Dnvm;
 /// Holds the simple name of a directory that contains one or more SDKs and lives under DNVM_HOME.
 /// This is a wrapper to prevent being used directly as a path.
 /// </summary>
-public readonly partial record struct SdkDirName(string Name);
+public readonly partial record struct SdkDirName(string Name)
+{
+    public string Name { get; init; } = Name.ToLowerInvariant();
+}
 
 [Closed]
 [GenerateSerde]

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -107,7 +107,7 @@ public class SelfInstallCommand
         }
 
         var updateUserEnv = args.UpdateUserEnvironment;
-        var sdkDirName = TrackCommand.GetSdkDirNameFromChannel(channel);
+        var sdkDirName = DnvmEnv.DefaultSdkDirName;
         if (!args.Yes && MissingFromEnv(env, sdkDirName))
         {
             Console.Write("One or more paths are missing from the user environment. Attempt to update the user environment? [Y/n] ");

--- a/src/dnvm/TrackCommand.cs
+++ b/src/dnvm/TrackCommand.cs
@@ -52,15 +52,7 @@ public sealed class TrackCommand
         // Use an explicit SdkDir if specified, otherwise, only the preview channel is isolated by
         // default.
         _sdkDir = args.SdkDir switch {
-            {} sdkDir => new SdkDirName(sdkDir.ToLowerInvariant()),
-            _ => GetSdkDirNameFromChannel(args.Channel)
-        };
-    }
-
-    internal static SdkDirName GetSdkDirNameFromChannel(Channel channel)
-    {
-        return channel switch {
-            Channel.Preview => new SdkDirName("preview"),
+            {} sdkDir => new SdkDirName(sdkDir),
             _ => DnvmEnv.DefaultSdkDirName
         };
     }

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -73,7 +73,7 @@ public sealed class InstallTests
     });
 
     [Fact]
-    public Task PreviewIsolated() => RunWithServer(async (server, env) =>
+    public Task PreviewNotIsolated() => RunWithServer(async (server, env) =>
     {
         server.ReleasesIndexJson = server.ReleasesIndexJson with {
             Releases = server.ReleasesIndexJson.Releases.Select(r => r with { SupportPhase = "preview" }).ToImmutableArray()
@@ -83,12 +83,12 @@ public sealed class InstallTests
         {
             Channel = Channel.Preview,
         };
-        // Check that the preview install is isolated into a "preview" subdirectory
-        var sdkInstallDir = DnvmEnv.GetSdkPath(new SdkDirName("preview"));
+        // Preview used to be isolated, but it shouldn't be anymore
+        var sdkInstallDir = DnvmEnv.GetSdkPath(DnvmEnv.DefaultSdkDirName);
         Assert.False(env.Vfs.DirectoryExists(sdkInstallDir));
         Assert.True(env.Vfs.DirectoryExists(UPath.Root));
         Assert.Equal(Result.Success, await TrackCommand.Run(env, _logger, args));
-        var dotnetFile = sdkInstallDir / (Utilities.DotnetExeName);
+        var dotnetFile = sdkInstallDir / Utilities.DotnetExeName;
         Assert.True(env.Vfs.FileExists(dotnetFile));
         Assert.Contains(Assets.ArchiveToken, env.Vfs.ReadAllText(dotnetFile));
     });

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -35,7 +35,7 @@ public sealed class SelectTests
             Channel = Channel.Preview,
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        var previewDotnet = DnvmEnv.GetSdkPath(new SdkDirName("preview")) / Utilities.DotnetExeName;
+        var previewDotnet = DnvmEnv.GetSdkPath(defaultSdkDir) / Utilities.DotnetExeName;
         Assert.True(homeFs.FileExists(previewDotnet));
 
         // Check that the dotnet link/cmd points to the default SDK
@@ -44,13 +44,12 @@ public sealed class SelectTests
 
         // Select the preview SDK
         var manifest = await env.ReadManifest();
-        Assert.Equal(DnvmEnv.DefaultSdkDirName, manifest.CurrentSdkDir);
+        Assert.Equal(defaultSdkDir, manifest.CurrentSdkDir);
 
-        var previewSdkDir = new SdkDirName("preview");
-        manifest = (await SelectCommand.RunWithManifest(env, previewSdkDir, manifest, _logger)).Unwrap();
+        manifest = (await SelectCommand.RunWithManifest(env, defaultSdkDir, manifest, _logger)).Unwrap();
 
-        Assert.Equal(previewSdkDir, manifest.CurrentSdkDir);
-        AssertSymlinkTarget(dotnetSymlink, previewSdkDir);
+        Assert.Equal(defaultSdkDir, manifest.CurrentSdkDir);
+        AssertSymlinkTarget(dotnetSymlink, defaultSdkDir);
     });
 
     [Fact]


### PR DESCRIPTION
Previously, preview versions were installed to the 'preview' folder to separate from the release versions. There are drawbacks to installing in the same folder, but they can mostly be addressed by using global.json. Using one folder is also preferred for the official product, so this matches the expected product layout.