### PR TITLE
Allow channels to overlap

### DIFF
--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Spectre.Console;
 
@@ -37,11 +38,13 @@ public static class ListCommand
         table.AddColumn("Version");
         table.AddColumn("Channel");
         table.AddColumn("Location");
-        foreach (var sdk in manifest.InstalledSdkVersions)
+        foreach (var sdk in manifest.InstalledSdks)
         {
             string selected = manifest.CurrentSdkDir == sdk.SdkDirName ? "*" : " ";
-            var channel = sdk.Channel?.GetLowerName() ?? "";
-            table.AddRow(selected, sdk.SdkVersion.ToString(), channel, sdk.SdkDirName.Name);
+            var channels = manifest.TrackedChannels
+                .Where(c => c.InstalledSdkVersions.Contains(sdk.SdkVersion))
+                .Select(c => c.ChannelName.ToString().ToLowerInvariant());
+            table.AddRow(selected, sdk.SdkVersion.ToString(), string.Join(", ", channels), sdk.SdkDirName.Name);
         }
         logger.Console.Write(table);
     }

--- a/src/dnvm/ManifestSchema/Manifest.cs
+++ b/src/dnvm/ManifestSchema/Manifest.cs
@@ -2,14 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Semver;
 using Serde;
 using Serde.Json;
-using StaticCs;
 using StaticCs.Collections;
 
 namespace Dnvm;
@@ -20,20 +17,27 @@ public sealed partial record Manifest
     public static readonly Manifest Empty = new();
 
     // Serde doesn't serialize consts, so we have a separate property below for serialization.
-    public const int VersionField = 5;
+    public const int VersionField = 6;
 
     [SerdeMemberOptions(SkipDeserialize = true)]
     public int Version => VersionField;
 
     public SdkDirName CurrentSdkDir { get; init; } = DnvmEnv.DefaultSdkDirName;
-    public EqArray<InstalledSdk> InstalledSdkVersions { get; init; } = [];
+    public EqArray<InstalledSdk> InstalledSdks { get; init; } = [];
     public EqArray<TrackedChannel> TrackedChannels { get; init; } = [];
 
     internal Manifest Untrack(Channel channel)
     {
         return this with
         {
-            TrackedChannels = TrackedChannels.Where(c => c.ChannelName != channel).ToEq()
+            TrackedChannels = TrackedChannels.Select(c =>
+            {
+                if (c.ChannelName == channel)
+                {
+                    return c with { Untracked = true };
+                }
+                return c;
+            }).ToEq()
         };
     }
 }
@@ -47,6 +51,7 @@ public partial record TrackedChannel
         WrapperSerialize = typeof(EqArraySerdeWrap.SerializeImpl<SemVersion, SemVersionSerdeWrap>),
         WrapperDeserialize = typeof(EqArraySerdeWrap.DeserializeImpl<SemVersion, SemVersionSerdeWrap>))]
     public EqArray<SemVersion> InstalledSdkVersions { get; init; } = EqArray<SemVersion>.Empty;
+    public bool Untracked { get; init; } = false;
 }
 
 [GenerateSerde]
@@ -62,79 +67,27 @@ public partial record InstalledSdk
     public required SemVersion AspNetVersion { get; init; }
 
     public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
-
-    /// <summary>
-    /// Indicates which channel this SDK was installed from, if any.
-    /// </summary>
-    public Channel? Channel { get; init; } = null;
 }
 
 public static partial class ManifestConvert
 {
-    public static async Task<Manifest> Convert(this ManifestV4 v4, DotnetReleasesIndex releasesIndex)
+    public static Manifest Convert(this ManifestV5 v5) => new Manifest
     {
-        var channelMemo = new SortedDictionary<SemVersion, ChannelReleaseIndex>(SemVersion.SortOrderComparer);
+        InstalledSdks = v5.InstalledSdkVersions.SelectAsArray(v => v.Convert()).ToEq(),
+        TrackedChannels = v5.TrackedChannels.SelectAsArray(c => c.Convert()).ToEq(),
+    };
 
-        var getChannelIndex = async (SemVersion majorMinor) =>
-        {
-            if (channelMemo.TryGetValue(majorMinor, out var channelReleaseIndex))
-            {
-                return channelReleaseIndex;
-            }
+    public static InstalledSdk Convert(this InstalledSdkV5 v5) => new InstalledSdk {
+        ReleaseVersion = v5.ReleaseVersion,
+        SdkVersion = v5.SdkVersion,
+        RuntimeVersion = v5.RuntimeVersion,
+        AspNetVersion = v5.AspNetVersion,
+        SdkDirName = v5.SdkDirName,
+    };
 
-            var channelRelease = releasesIndex.Releases.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
-            channelReleaseIndex = JsonSerializer.Deserialize<ChannelReleaseIndex>(
-                await Program.HttpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
-            channelMemo[majorMinor] = channelReleaseIndex;
-            return channelReleaseIndex;
-        };
-
-        return new Manifest
-        {
-            InstalledSdkVersions = (await v4.InstalledSdkVersions.SelectAsArray(v => v.Convert(v4, getChannelIndex))).ToEq(),
-            TrackedChannels = v4.TrackedChannels.SelectAsArray(c => c.Convert()).ToEq(),
-        };
-    }
-
-    public static async Task<InstalledSdk> Convert(
-        this InstalledSdkV4 v4,
-        ManifestV4 manifestV4,
-        Func<SemVersion, Task<ChannelReleaseIndex>> getChannelIndex)
-    {
-        // Take the major and minor version from the installed SDK and use it to find the corresponding
-        // version in the releases index. Then grab the component versions from that release and fill
-        // in the remaining sections in the InstalledSdk
-        var v4Version = SemVersion.Parse(v4.Version, SemVersionStyles.Strict);
-        var majorMinorVersion = new SemVersion(v4Version.Major, v4Version.Minor);
-
-        var channelReleaseIndex = await getChannelIndex(majorMinorVersion);
-        var exactRelease = channelReleaseIndex.Releases
-            .Where(r => r.Sdks.Contains(new() { Version = v4Version}))
-            .Single();
-
-
-        Channel? channel = (v4Version.Major, v4Version.Minor) switch {
-            (6, 0) => Channel.Lts,
-            (7, 0) => Channel.Latest,
-            (8, 0) => Channel.Preview,
-            _ => manifestV4.TrackedChannels
-                 .SingleOrNull(c => c.SdkDirName == v4.SdkDirName)?.ChannelName
-        } ;
-
-        return new InstalledSdk()
-        {
-            ReleaseVersion = exactRelease.ReleaseVersion,
-            SdkVersion = v4Version,
-            RuntimeVersion = exactRelease.Runtime.Version,
-            AspNetVersion = exactRelease.AspNetCore.Version,
-            SdkDirName = v4.SdkDirName,
-            Channel = channel
-        };
-    }
-
-    public static TrackedChannel Convert(this TrackedChannelV4 v3) => new TrackedChannel {
-        ChannelName = v3.ChannelName,
-        SdkDirName = v3.SdkDirName,
-        InstalledSdkVersions = v3.InstalledSdkVersions.Select(v => SemVersion.Parse(v, SemVersionStyles.Strict)).ToEq(),
+    public static TrackedChannel Convert(this TrackedChannelV5 v5) => new TrackedChannel {
+        ChannelName = v5.ChannelName,
+        SdkDirName = v5.SdkDirName,
+        InstalledSdkVersions = v5.InstalledSdkVersions
     };
 }

--- a/src/dnvm/ManifestSchema/ManifestV5.cs
+++ b/src/dnvm/ManifestSchema/ManifestV5.cs
@@ -1,0 +1,140 @@
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Semver;
+using Serde;
+using Serde.Json;
+using StaticCs;
+using StaticCs.Collections;
+
+namespace Dnvm;
+
+[GenerateSerde]
+public sealed partial record ManifestV5
+{
+    public static readonly ManifestV5 Empty = new();
+
+    // Serde doesn't serialize consts, so we have a separate property below for serialization.
+    public const int VersionField = 5;
+
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public int Version => VersionField;
+
+    public SdkDirName CurrentSdkDir { get; init; } = DnvmEnv.DefaultSdkDirName;
+    public EqArray<InstalledSdkV5> InstalledSdkVersions { get; init; } = [];
+    public EqArray<TrackedChannelV5> TrackedChannels { get; init; } = [];
+
+    internal ManifestV5 Untrack(Channel channel)
+    {
+        return this with
+        {
+            TrackedChannels = TrackedChannels.Where(c => c.ChannelName != channel).ToEq()
+        };
+    }
+}
+
+[GenerateSerde]
+public partial record TrackedChannelV5
+{
+    public required Channel ChannelName { get; init; }
+    public required SdkDirName SdkDirName { get; init; }
+    [SerdeMemberOptions(
+        WrapperSerialize = typeof(EqArraySerdeWrap.SerializeImpl<SemVersion, SemVersionSerdeWrap>),
+        WrapperDeserialize = typeof(EqArraySerdeWrap.DeserializeImpl<SemVersion, SemVersionSerdeWrap>))]
+    public EqArray<SemVersion> InstalledSdkVersions { get; init; } = EqArray<SemVersion>.Empty;
+}
+
+[GenerateSerde]
+public partial record InstalledSdkV5
+{
+    [SerdeWrap(typeof(SemVersionSerdeWrap))]
+    public required SemVersion ReleaseVersion { get; init; }
+    [SerdeWrap(typeof(SemVersionSerdeWrap))]
+    public required SemVersion SdkVersion { get; init; }
+    [SerdeWrap(typeof(SemVersionSerdeWrap))]
+    public required SemVersion RuntimeVersion { get; init; }
+    [SerdeWrap(typeof(SemVersionSerdeWrap))]
+    public required SemVersion AspNetVersion { get; init; }
+
+    public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
+
+    /// <summary>
+    /// Indicates which channel this SDK was installed from, if any.
+    /// </summary>
+    public Channel? Channel { get; init; } = null;
+}
+
+public static partial class ManifestV5Convert
+{
+    public static async Task<ManifestV5> Convert(this ManifestV4 v4, DotnetReleasesIndex releasesIndex)
+    {
+        var channelMemo = new SortedDictionary<SemVersion, ChannelReleaseIndex>(SemVersion.SortOrderComparer);
+
+        var getChannelIndex = async (SemVersion majorMinor) =>
+        {
+            if (channelMemo.TryGetValue(majorMinor, out var channelReleaseIndex))
+            {
+                return channelReleaseIndex;
+            }
+
+            var channelRelease = releasesIndex.Releases.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
+            channelReleaseIndex = JsonSerializer.Deserialize<ChannelReleaseIndex>(
+                await Program.HttpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
+            channelMemo[majorMinor] = channelReleaseIndex;
+            return channelReleaseIndex;
+        };
+
+        return new ManifestV5
+        {
+            InstalledSdkVersions = (await v4.InstalledSdkVersions.SelectAsArray(v => v.Convert(v4, getChannelIndex))).ToEq(),
+            TrackedChannels = v4.TrackedChannels.SelectAsArray(c => c.Convert()).ToEq(),
+        };
+    }
+
+    public static async Task<InstalledSdkV5> Convert(
+        this InstalledSdkV4 v4,
+        ManifestV4 manifestV4,
+        Func<SemVersion, Task<ChannelReleaseIndex>> getChannelIndex)
+    {
+        // Take the major and minor version from the installed SDK and use it to find the corresponding
+        // version in the releases index. Then grab the component versions from that release and fill
+        // in the remaining sections in the InstalledSdkV5
+        var v4Version = SemVersion.Parse(v4.Version, SemVersionStyles.Strict);
+        var majorMinorVersion = new SemVersion(v4Version.Major, v4Version.Minor);
+
+        var channelReleaseIndex = await getChannelIndex(majorMinorVersion);
+        var exactRelease = channelReleaseIndex.Releases
+            .Where(r => r.Sdks.Contains(new() { Version = v4Version}))
+            .Single();
+
+
+        Channel? channel = (v4Version.Major, v4Version.Minor) switch {
+            (6, 0) => Channel.Lts,
+            (7, 0) => Channel.Latest,
+            (8, 0) => Channel.Preview,
+            _ => manifestV4.TrackedChannels
+                 .SingleOrNull(c => c.SdkDirName == v4.SdkDirName)?.ChannelName
+        } ;
+
+        return new InstalledSdkV5()
+        {
+            ReleaseVersion = exactRelease.ReleaseVersion,
+            SdkVersion = v4Version,
+            RuntimeVersion = exactRelease.Runtime.Version,
+            AspNetVersion = exactRelease.AspNetCore.Version,
+            SdkDirName = v4.SdkDirName,
+            Channel = channel
+        };
+    }
+
+    public static TrackedChannelV5 Convert(this TrackedChannelV4 v3) => new TrackedChannelV5 {
+        ChannelName = v3.ChannelName,
+        SdkDirName = v3.SdkDirName,
+        InstalledSdkVersions = v3.InstalledSdkVersions.Select(v => SemVersion.Parse(v, SemVersionStyles.Strict)).ToEq(),
+    };
+}

--- a/src/dnvm/PruneCommand.cs
+++ b/src/dnvm/PruneCommand.cs
@@ -50,7 +50,7 @@ public sealed class PruneCommand
     {
         var latestMajorMinorInDirs = new Dictionary<(SdkDirName Dir, string MajorMinor), SemVersion>();
         var sdksToRemove = new List<(SemVersion, SdkDirName)>();
-        foreach (var sdk in manifest.InstalledSdkVersions)
+        foreach (var sdk in manifest.InstalledSdks)
         {
             var majorMinor = sdk.SdkVersion.ToMajorMinor();
             var dir = sdk.SdkDirName;

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -19,9 +19,8 @@ public sealed class UninstallCommand
         }
         catch (Exception e)
         {
-            Environment.FailFast("Error reading manifest: ", e);
-            // unreachable
-            return 1;
+            logger.Error($"Error reading manifest: {e.Message}");
+            throw;
         }
 
         var runtimesToKeep = new HashSet<(SemVersion, SdkDirName)>();
@@ -32,7 +31,7 @@ public sealed class UninstallCommand
         var winToKeep = new HashSet<(SemVersion, SdkDirName)>();
         var winToRemove = new HashSet<(SemVersion, SdkDirName)>();
 
-        foreach (var installed in manifest.InstalledSdkVersions)
+        foreach (var installed in manifest.InstalledSdks)
         {
             if (installed.SdkVersion == args.SdkVersion && (args.Dir is null || installed.SdkDirName == args.Dir))
             {
@@ -134,11 +133,11 @@ public sealed class UninstallCommand
     private static Manifest UninstallSdk(Manifest manifest, SemVersion sdkVersion)
     {
         // Delete SDK version from all directories
-        var newVersions = manifest.InstalledSdkVersions
+        var newVersions = manifest.InstalledSdks
             .Where(sdk => sdk.SdkVersion != sdkVersion)
             .ToEq();
         return manifest with {
-            InstalledSdkVersions = newVersions,
+            InstalledSdks = newVersions,
         };
     }
 }

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -69,6 +69,16 @@ public static class Utilities
         return builder.MoveToImmutable();
     }
 
+    public static EqArray<U> SelectAsArray<T, U>(this EqArray<T> e, Func<T, U> f)
+    {
+        var builder = ImmutableArray.CreateBuilder<U>(e.Length);
+        foreach (var item in e)
+        {
+            builder.Add(f(item));
+        }
+        return new(builder.MoveToImmutable());
+    }
+
     public static async Task<ImmutableArray<U>> SelectAsArray<T, U>(this ImmutableArray<T> e, Func<T, Task<U>> f)
     {
         var builder = ImmutableArray.CreateBuilder<U>(e.Length);

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -65,14 +65,14 @@ public sealed class MockServer : IAsyncDisposable
     }
 
     [MemberNotNull(nameof(ReleasesIndexJson))]
-    private void RegisterReleaseVersion(SemVersion ltsVersion, string releaseType, string supportPhase)
+    public ChannelReleaseIndex.Release RegisterReleaseVersion(SemVersion version, string releaseType, string supportPhase)
     {
-        var majorMinor = ltsVersion.ToMajorMinor();
+        var majorMinor = version.ToMajorMinor();
         ReleasesIndexJson ??= new DotnetReleasesIndex{ Releases = [ ] };
         ReleasesIndexJson = ReleasesIndexJson with {
             Releases = ReleasesIndexJson.Releases.Add(new() {
-                LatestRelease = ltsVersion.ToString(),
-                LatestSdk = ltsVersion.ToString(),
+                LatestRelease = version.ToString(),
+                LatestSdk = version.ToString(),
                 MajorMinorVersion = majorMinor,
                 ReleaseType = releaseType,
                 SupportPhase = supportPhase,
@@ -83,10 +83,12 @@ public sealed class MockServer : IAsyncDisposable
         {
             index = new() { Releases = [] };
         }
+        var newRelease = ChannelReleaseIndex.CreateRelease(version);
         index = index with {
-            Releases = index.Releases.Add(ChannelReleaseIndex.CreateRelease(ltsVersion))
+            Releases = index.Releases.Add(newRelease)
         };
         ChannelIndexMap[majorMinor] = index;
+        return newRelease;
     }
 
     private async Task WaitForConnection()

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -26,15 +26,13 @@ public sealed class ListTests
                 SdkVersion = new(1,0,0),
                 RuntimeVersion = new(1,0,0),
                 AspNetVersion = new(1,0,0),
-                ReleaseVersion = new(1,0,0),
-                Channel = Channel.Latest }, Channel.Latest)
+                ReleaseVersion = new(1,0,0) }, Channel.Latest)
             .AddSdk(new InstalledSdk() {
                 SdkVersion = previewVersion,
                 RuntimeVersion = previewVersion,
                 AspNetVersion = previewVersion,
                 ReleaseVersion = previewVersion,
-                SdkDirName = new("preview"),
-                Channel = Channel.Preview }, Channel.Preview);
+                SdkDirName = new("preview") }, Channel.Preview);
 
         ListCommand.PrintSdks(_logger, manifest);
         var output = """
@@ -60,7 +58,6 @@ Installed SDKs:
                 RuntimeVersion = new(42, 42, 42),
                 AspNetVersion = new(42, 42, 42),
                 ReleaseVersion = new(42, 42, 42),
-                Channel = Channel.Latest
             }, Channel.Latest);
 
         var env = new Dictionary<string, string>();

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -5,6 +5,7 @@ using Dnvm;
 using Dnvm.Test;
 using Semver;
 using Xunit;
+using System.Net.NetworkInformation;
 
 public sealed class ManifestTests
 {
@@ -33,7 +34,7 @@ public sealed class ManifestTests
     "installedSdkVersions":[{"version":"7.0.203","sdkDirName":{"name":"dn"}},{"version":"8.0.100-preview.3.23178.7","sdkDirName":{"name":"preview"}}],
     "trackedChannels":[
         {"channelName":"latest","sdkDirName":{"name":"dn"},"installedSdkVersions":["7.0.203"]},
-        {"channelName":"preview","sdkDirName":{"name":"dn"},"installedSdkVersions":["8.0.100-rc.1.23455.8"]}
+        {"channelName":"preview","sdkDirName":{"name":"dn"},"installedSdkVersions":["8.0.100-preview.3.23178.7"]}
     ]
 }
 """;
@@ -88,8 +89,8 @@ public sealed class ManifestTests
         });
 
         var v5 = (await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrl))!;
-        Assert.Equal(Channel.Latest, v5.InstalledSdkVersions[0].Channel);
-        Assert.Equal(Channel.Preview, v5.InstalledSdkVersions[1].Channel);
+        Assert.Equal(Channel.Latest, v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[0].SdkVersion)).ChannelName);
+        Assert.Equal(Channel.Preview, v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[1].SdkVersion)).ChannelName);
     });
 
     [Fact]

--- a/test/UnitTests/PruneTests.cs
+++ b/test/UnitTests/PruneTests.cs
@@ -29,7 +29,7 @@ public sealed class PruneTests
 
         var outOfDate = PruneCommand.GetOutOfDateSdks(manifest);
 
-        var item1 = manifest.InstalledSdkVersions[0];
+        var item1 = manifest.InstalledSdks[0];
         List<(SemVersion, SdkDirName)> expected = [ (item1.SdkVersion, item1.SdkDirName) ];
         Assert.Equal(expected, outOfDate);
     }

--- a/test/UnitTests/UntrackTests.cs
+++ b/test/UnitTests/UntrackTests.cs
@@ -36,7 +36,7 @@ public sealed class UntrackTests
         var result = UntrackCommand.RunHelper(Channel.Latest, manifest, logger);
         if (result is UntrackCommand.Result.Success({} newManifest))
         {
-            Assert.Empty(newManifest.TrackedChannels);
+            Assert.True(Assert.Single(newManifest.TrackedChannels).Untracked);
         }
         else
         {


### PR DESCRIPTION
Multiple channels may target the same major-minor release. This should be fine. The requested SDKs should only be installed once, but they should be present in the install list of each tracked channel that wants one.