### PR TITLE
Add initial support for tracking minor-major versions

### DIFF
--- a/src/dnvm/Channel.cs
+++ b/src/dnvm/Channel.cs
@@ -1,0 +1,122 @@
+
+using Semver;
+using Serde;
+using StaticCs;
+
+namespace Dnvm;
+
+public static class Channels
+{
+    public static string GetDesc(this Channel c) => c switch
+    {
+        Channel.Versioned v => $"The latest version in the {v} support channel",
+        Channel.Lts => "The latest version in Long-Term support",
+        Channel.Sts => "The latest version in Short-Term support",
+        Channel.Latest => "The latest supported version from either the LTS or STS support channels.",
+        Channel.Preview => "The latest preview version",
+    };
+
+    public static string GetLowerName(this Channel c) => c switch
+    {
+        Channel.Versioned v => v.ToString(),
+        Channel.Lts => "lts",
+        Channel.Sts => "sts",
+        Channel.Latest => "latest",
+        Channel.Preview => "preview",
+    };
+    public static string GetDisplayName(this Channel c) => c switch
+    {
+        Channel.Versioned v => v.ToString(),
+        Channel.Lts => "LTS",
+        Channel.Sts => "STS",
+        Channel.Latest => "Latest",
+        Channel.Preview => "Preview",
+    };
+}
+
+
+[Closed]
+public abstract partial record Channel
+{
+    private Channel() { }
+
+    /// <summary>
+    /// A major-minor versioned channel.
+    /// </summary>
+    public sealed partial record Versioned(int Major, int Minor) : Channel;
+    /// <summary>
+    /// Newest Long Term Support release.
+    /// </summary>
+    public sealed partial record Lts : Channel;
+    /// <summary>
+    /// Newest Short Term Support release.
+    /// </summary>
+    public sealed partial record Sts : Channel;
+    /// <summary>
+    /// Latest supported version from either the LTS or STS support channels.
+    /// </summary>
+    public sealed partial record Latest : Channel;
+    /// <summary>
+    /// Latest preview version.
+    /// </summary>
+    public sealed partial record Preview : Channel;
+}
+
+partial record Channel : ISerialize
+{
+    protected abstract void Serialize(ISerializer serializer);
+    void ISerialize.Serialize(ISerializer serializer) => Serialize(serializer);
+
+    partial record Versioned
+    {
+        public override string ToString() => $"{Major}.{Minor}";
+
+        protected override void Serialize(ISerializer serializer)
+            => serializer.SerializeString(this.ToString());
+    }
+    partial record Lts : Channel
+    {
+        protected override void Serialize(ISerializer serializer)
+            => serializer.SerializeString("lts");
+    }
+    partial record Sts : Channel
+    {
+        protected override void Serialize(ISerializer serializer)
+            => serializer.SerializeString("sts");
+    }
+    partial record Latest : Channel
+    {
+        protected override void Serialize(ISerializer serializer)
+            => serializer.SerializeString("latest");
+    }
+    partial record Preview : Channel
+    {
+        protected override void Serialize(ISerializer serializer)
+            => serializer.SerializeString("preview");
+    }
+}
+
+partial record Channel : IDeserialize<Channel>
+{
+    public static Channel Deserialize<D>(ref D deserializer)
+        where D : IDeserializer
+    {
+        var str = StringWrap.Deserialize(ref deserializer);
+        switch (str)
+        {
+            case "lts": return new Lts();
+            case "sts": return new Sts();
+            case "latest": return new Latest();
+            case "preview": return new Preview();
+            default:
+                var components = str.Split('.');
+                if (components.Length != 2)
+                {
+                    throw new InvalidDeserializeValueException($"Invalid channel version: {str}");
+                }
+                var major = int.Parse(components[0]);
+                var minor = int.Parse(components[1]);
+                return new Versioned(major, minor);
+        }
+    }
+}

--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -43,7 +43,7 @@ public static class ListCommand
             string selected = manifest.CurrentSdkDir == sdk.SdkDirName ? "*" : " ";
             var channels = manifest.TrackedChannels
                 .Where(c => c.InstalledSdkVersions.Contains(sdk.SdkVersion))
-                .Select(c => c.ChannelName.ToString().ToLowerInvariant());
+                .Select(c => c.ChannelName.GetLowerName());
             table.AddRow(selected, sdk.SdkVersion.ToString(), string.Join(", ", channels), sdk.SdkDirName.Name);
         }
         logger.Console.Write(table);

--- a/src/dnvm/ManifestSchema/ManifestV5.cs
+++ b/src/dnvm/ManifestSchema/ManifestV5.cs
@@ -114,9 +114,9 @@ public static partial class ManifestV5Convert
 
 
         Channel? channel = (v4Version.Major, v4Version.Minor) switch {
-            (6, 0) => Channel.Lts,
-            (7, 0) => Channel.Latest,
-            (8, 0) => Channel.Preview,
+            (6, 0) => new Channel.Lts(),
+            (7, 0) => new Channel.Latest(),
+            (8, 0) => new Channel.Preview(),
             _ => manifestV4.TrackedChannels
                  .SingleOrNull(c => c.SdkDirName == v4.SdkDirName)?.ChannelName
         } ;

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Semver;
 using Serde;
@@ -21,44 +22,6 @@ namespace Dnvm;
 public readonly partial record struct SdkDirName(string Name)
 {
     public string Name { get; init; } = Name.ToLowerInvariant();
-}
-
-[Closed]
-[GenerateSerde]
-public enum Channel
-{
-    /// <summary>
-    /// Latest supported version from either the LTS or STS support channels.
-    /// </summary>
-    Latest,
-    /// <summary>
-    /// Newest Long Term Support release.
-    /// </summary>
-    Lts,
-    /// <summary>
-    /// Newest Short Term Support release.
-    /// </summary>
-    Sts,
-
-    /// </summary>
-    /// <summary>
-    /// Newest "preview" release, not including nightly builds.
-    /// </summary>
-    Preview,
-}
-
-public static class Channels
-{
-    public static string GetDesc(this Channel c) => c switch
-    {
-        Channel.Latest => "The latest supported version from either the LTS or STS support channels.",
-        Channel.Lts => "The latest version in Long-Term support",
-        Channel.Sts => "The latest version in Short-Term support",
-        Channel.Preview => "The latest preview version",
-        _ => throw new NotImplementedException(),
-    };
-
-    public static string GetLowerName(this Channel c) => c.ToString().ToLowerInvariant();
 }
 
 

--- a/src/dnvm/ScalarDeserializer.cs
+++ b/src/dnvm/ScalarDeserializer.cs
@@ -1,0 +1,70 @@
+
+using System;
+using Serde;
+
+namespace Dnvm;
+
+public struct ScalarDeserializer(string s) : IDeserializer
+{
+    public T DeserializeAny<T, V>(V v) where V : IDeserializeVisitor<T>
+    {
+        throw new NotImplementedException();
+    }
+
+    public T DeserializeBool<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitBool(bool.Parse(s));
+
+    public T DeserializeByte<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitByte(byte.Parse(s));
+
+    public T DeserializeChar<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitChar(char.Parse(s));
+
+    public T DeserializeDecimal<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitDecimal(decimal.Parse(s));
+
+    public T DeserializeDictionary<T, V>(V v) where V : IDeserializeVisitor<T>
+        => throw new InvalidDeserializeValueException("Found dictionary, expected scalar");
+
+    public T DeserializeDouble<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitDouble(double.Parse(s));
+
+    public T DeserializeEnumerable<T, V>(V v) where V : IDeserializeVisitor<T>
+        => throw new InvalidDeserializeValueException("Found enumerable, expected scalar");
+
+    public T DeserializeFloat<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitFloat(float.Parse(s));
+
+    public T DeserializeI16<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitI16(short.Parse(s));
+
+    public T DeserializeI32<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitI32(int.Parse(s));
+
+    public T DeserializeI64<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitI64(long.Parse(s));
+
+    public T DeserializeIdentifier<T, V>(V v) where V : IDeserializeVisitor<T>
+        => throw new InvalidDeserializeValueException("Found identifier, expected scalar");
+
+    public T DeserializeNullableRef<T, V>(V v) where V : IDeserializeVisitor<T>
+        => throw new InvalidDeserializeValueException("Found nullable ref, expected scalar");
+
+    public T DeserializeSByte<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitSByte(sbyte.Parse(s));
+
+    public T DeserializeString<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitString(s);
+
+    public T DeserializeType<T, V>(string typeName, ReadOnlySpan<string> fieldNames, V v) where V : IDeserializeVisitor<T>
+        => throw new InvalidDeserializeValueException("Found type, expected scalar");
+
+    public T DeserializeU16<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitU16(ushort.Parse(s));
+
+    public T DeserializeU32<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitU32(uint.Parse(s));
+
+    public T DeserializeU64<T, V>(V v) where V : IDeserializeVisitor<T>
+        => v.VisitU64(ulong.Parse(s));
+}

--- a/src/dnvm/dnvm.csproj
+++ b/src/dnvm/dnvm.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serde" Version="0.5.3" />
 
     <PackageReference Include="Spectre.Console" Version="0.46.0" />
-    <PackageReference Include="StaticCs" Version="0.2.0" />
+    <PackageReference Include="StaticCs" Version="0.3.1" />
     <PackageReference Include="StaticCs.Collections" Version="1.0.1" />
     <PackageReference Include="zio" Version="0.16.2" />
   </ItemGroup>

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Zio;
 using static Dnvm.Test.TestUtils;
+using static System.Environment;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace Dnvm.Test;
@@ -45,6 +46,105 @@ public sealed class SelfInstallTests
 
         var result = await ProcUtil.RunWithOutput(env.RealPath(dotnetPath), "-h");
         Assert.Contains(Assets.ArchiveToken, result.Out);
+    });
+
+    [Fact]
+    public Task SelfInstallDialog() => RunWithServer(async (mockServer, env) =>
+    {
+        var buffer = new char[1024];
+        var psi = new ProcessStartInfo
+        {
+            FileName = DnvmExe,
+            Arguments = $"selfinstall --feed-url {mockServer.PrefixString} -v",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            EnvironmentVariables = {
+                ["HOME"] = env.UserHome,
+                ["DNVM_HOME"] = env.RealPath(UPath.Root)
+            }
+        };
+        var proc = Process.Start(psi)!;
+        // Discard the first two lines -- they're the prolog
+        for (int i = 0; i < 2; i++)
+        {
+            _ = await proc.StandardOutput.ReadLineAsync() + Environment.NewLine;
+        }
+        var lines = "";
+        for (int i = 0; i < 2; i++)
+        {
+            lines += await proc.StandardOutput.ReadLineAsync() + Environment.NewLine;
+        }
+        Assert.Equal($"""
+Starting dnvm install
+Please select install location [default: {env.RealPath(UPath.Root)}]:
+""", lines.Trim());
+
+        // Flush output
+        await proc.StandardOutput.ReadAsync(buffer);
+        // Write empty line -- use the default
+        await proc.StandardInput.WriteLineAsync();
+
+        lines = "";
+        for (int i = 0; i < 8; i++)
+        {
+            lines += await proc.StandardOutput.ReadLineAsync() + Environment.NewLine;
+        }
+        Assert.Equal("""
+Which channel would you like to start tracking?
+Available channels:
+	1) Latest - The latest supported version from either the LTS or STS support channels.
+	2) STS - The latest version in Short-Term support
+	3) LTS - The latest version in Long-Term support
+	4) Preview - The latest preview version
+
+Please select a channel [default: Latest]:
+""", lines.Trim());
+
+        // Flush output
+        await proc.StandardOutput.ReadAsync(buffer);
+        // Use 'preview'
+        await proc.StandardInput.WriteLineAsync("4");
+
+        lines = await proc.StandardOutput.ReadLineAsync();
+        Assert.Equal("One or more paths are missing from the user environment. Attempt to update the user environment?", lines);
+
+        // Flush output
+        await proc.StandardOutput.ReadAsync(buffer);
+        // Say yes
+        await proc.StandardInput.WriteLineAsync("y");
+
+        lines = "";
+        for (int i = 0; i < 8; i++)
+        {
+            lines += await proc.StandardOutput.ReadLineAsync() + Environment.NewLine;
+        }
+
+        Assert.Equal($"""
+Proceeding with installation.
+Log: Location of running exe: {NewLine}{DnvmExe}
+Log: Copying file from {NewLine}'{DnvmExe}'
+to '/dnvm'
+Dnvm installed successfully.
+Found latest version: 99.99.99-preview
+
+""", lines);
+
+        do
+        {
+            lines = await proc.StandardOutput.ReadLineAsync();
+        } while (lines != null && !lines.Contains("Writing env sh file"));
+
+        lines = await proc.StandardOutput.ReadToEndAsync();
+        Assert.Equal($"""
+Log: Setting environment variables in shell files
+Scanning for shell files to update
+Log: Checking for file: {NewLine}{env.UserHome}/.profile
+Log: Checking for file: {NewLine}{env.UserHome}/.bashrc
+Log: Checking for file: {NewLine}{env.UserHome}/.zshrc
+
+""", lines);
+        Assert.Contains(env.RealPath(UPath.Root), env.Vfs.ReadAllText(DnvmEnv.EnvPath));
     });
 
     [ConditionalFact(typeof(UnixOnly))]

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -123,8 +123,7 @@ Please select a channel [default: Latest]:
         Assert.Equal($"""
 Proceeding with installation.
 Log: Location of running exe: {DnvmExe}
-Log: Copying file from '{DnvmExe}'
-to '/dnvm'
+Log: Copying file from '{DnvmExe}' to '/dnvm'
 Dnvm installed successfully.
 Found latest version: 99.99.99-preview
 """.StripNewlines(), lines);

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -49,7 +49,7 @@ public sealed class SelfInstallTests
         Assert.Contains(Assets.ArchiveToken, result.Out);
     });
 
-    [Fact]
+    [ConditionalFact(typeof(UnixOnly))]
     public Task SelfInstallDialog() => RunWithServer(async (mockServer, env) =>
     {
         var buffer = new char[1024];

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -1,4 +1,5 @@
 
+using Spectre.Console;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
@@ -126,7 +127,7 @@ Log: Location of running exe: {DnvmExe}
 Log: Copying file from '{DnvmExe}' to '/dnvm'
 Dnvm installed successfully.
 Found latest version: 99.99.99-preview
-""".StripNewlines(), lines);
+""".RemoveWhitespace(), lines.RemoveWhitespace());
 
         do
         {
@@ -140,7 +141,7 @@ Scanning for shell files to update
 Log: Checking for file: {env.UserHome}/.profile
 Log: Checking for file: {env.UserHome}/.bashrc
 Log: Checking for file: {env.UserHome}/.zshrc
-""".StripNewlines(), lines.StripNewlines());
+""".RemoveWhitespace(), lines.RemoveWhitespace());
         Assert.Contains(env.RealPath(UPath.Root), env.Vfs.ReadAllText(DnvmEnv.EnvPath));
     });
 

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -117,18 +117,17 @@ Please select a channel [default: Latest]:
         lines = "";
         for (int i = 0; i < 8; i++)
         {
-            lines += await proc.StandardOutput.ReadLineAsync() + Environment.NewLine;
+            lines += await proc.StandardOutput.ReadLineAsync();
         }
 
         Assert.Equal($"""
 Proceeding with installation.
-Log: Location of running exe: {NewLine}{DnvmExe}
-Log: Copying file from {NewLine}'{DnvmExe}'
+Log: Location of running exe: {DnvmExe}
+Log: Copying file from '{DnvmExe}'
 to '/dnvm'
 Dnvm installed successfully.
 Found latest version: 99.99.99-preview
-
-""", lines);
+""".StripNewlines(), lines);
 
         do
         {
@@ -139,11 +138,10 @@ Found latest version: 99.99.99-preview
         Assert.Equal($"""
 Log: Setting environment variables in shell files
 Scanning for shell files to update
-Log: Checking for file: {NewLine}{env.UserHome}/.profile
-Log: Checking for file: {NewLine}{env.UserHome}/.bashrc
-Log: Checking for file: {NewLine}{env.UserHome}/.zshrc
-
-""", lines);
+Log: Checking for file: {env.UserHome}/.profile
+Log: Checking for file: {env.UserHome}/.bashrc
+Log: Checking for file: {env.UserHome}/.zshrc
+""".StripNewlines(), lines.StripNewlines());
         Assert.Contains(env.RealPath(UPath.Root), env.Vfs.ReadAllText(DnvmEnv.EnvPath));
     });
 

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -124,7 +124,7 @@ Please select a channel [default: Latest]:
         Assert.Equal($"""
 Proceeding with installation.
 Log: Location of running exe: {DnvmExe}
-Log: Copying file from '{DnvmExe}' to '/dnvm'
+Log: Copying file from '{DnvmExe}' to '{DnvmEnv.DnvmExePath}'
 Dnvm installed successfully.
 Found latest version: 99.99.99-preview
 """.RemoveWhitespace(), lines.RemoveWhitespace());

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -108,7 +108,11 @@ public sealed class MockServer : IAsyncDisposable
 
             if (UrlToHandler.TryGetValue(ctx.Request.Url!.LocalPath.ToLowerInvariant(), out var action))
             {
+                try
+                {
                 action(ctx.Response);
+                }
+                catch {}
             }
             else
             {

--- a/test/Shared/TestUtils.cs
+++ b/test/Shared/TestUtils.cs
@@ -33,4 +33,6 @@ public static class TestUtils
             using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl);
             await test(mockServer, testOptions.DnvmEnv);
         });
+
+    public static string StripNewlines(this string input) => input.Replace("\r", "").Replace("\n", "");
 }

--- a/test/Shared/TestUtils.cs
+++ b/test/Shared/TestUtils.cs
@@ -34,5 +34,5 @@ public static class TestUtils
             await test(mockServer, testOptions.DnvmEnv);
         });
 
-    public static string StripNewlines(this string input) => input.Replace("\r", "").Replace("\n", "");
+    public static string RemoveWhitespace(this string input) => input.Replace("\r", "").Replace("\n", "").Replace(" ", "");
 }

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -26,13 +26,13 @@ public sealed class ListTests
                 SdkVersion = new(1,0,0),
                 RuntimeVersion = new(1,0,0),
                 AspNetVersion = new(1,0,0),
-                ReleaseVersion = new(1,0,0) }, Channel.Latest)
+                ReleaseVersion = new(1,0,0) }, new Channel.Latest())
             .AddSdk(new InstalledSdk() {
                 SdkVersion = previewVersion,
                 RuntimeVersion = previewVersion,
                 AspNetVersion = previewVersion,
                 ReleaseVersion = previewVersion,
-                SdkDirName = new("preview") }, Channel.Preview);
+                SdkDirName = new("preview") }, new Channel.Preview());
 
         ListCommand.PrintSdks(_logger, manifest);
         var output = """
@@ -58,7 +58,7 @@ Installed SDKs:
                 RuntimeVersion = new(42, 42, 42),
                 AspNetVersion = new(42, 42, 42),
                 ReleaseVersion = new(42, 42, 42),
-            }, Channel.Latest);
+            }, new Channel.Latest());
 
         var env = new Dictionary<string, string>();
         using var userHome = new TempDirectory();

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -89,20 +89,20 @@ public sealed class ManifestTests
         });
 
         var v5 = (await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrl))!;
-        Assert.Equal(Channel.Latest, v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[0].SdkVersion)).ChannelName);
-        Assert.Equal(Channel.Preview, v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[1].SdkVersion)).ChannelName);
+        Assert.Equal(new Channel.Latest(), v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[0].SdkVersion)).ChannelName);
+        Assert.Equal(new Channel.Preview(), v5.TrackedChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[1].SdkVersion)).ChannelName);
     });
 
     [Fact]
     public Task ManifestV3Convert() => TestUtils.RunWithServer(async server =>
     {
         var v3 = ManifestV3.Empty
-            .AddSdk(new InstalledSdkV3("42.42.42"), Channel.Latest)
+            .AddSdk(new InstalledSdkV3("42.42.42"), new Channel.Latest())
             .AddSdk(new InstalledSdkV3("99.99.99-preview")
                     { SdkDirName = new("preview") },
-                    Channel.Preview);
+                    new Channel.Preview());
         var v5 = await v3.Convert().Convert(server.ReleasesIndexJson);
-        Assert.Equal(Channel.Latest, v5.InstalledSdkVersions[0].Channel);
-        Assert.Equal(Channel.Preview, v5.InstalledSdkVersions[1].Channel);
+        Assert.Equal(new Channel.Latest(), v5.InstalledSdkVersions[0].Channel);
+        Assert.Equal(new Channel.Preview(), v5.InstalledSdkVersions[1].Channel);
     });
 }

--- a/test/UnitTests/PruneTests.cs
+++ b/test/UnitTests/PruneTests.cs
@@ -10,9 +10,9 @@ public sealed class PruneTests
     public void OutOfDateInOneDir()
     {
         var manifest = Manifest.Empty
-            .AddSdk(new(42, 42, 42), Channel.Latest, new("dn"))
-            .AddSdk(new(42, 42, 43), Channel.Preview, new("dn"))
-            .AddSdk(new(42, 42, 42), Channel.Preview, new("preview"));
+            .AddSdk(new(42, 42, 42), new Channel.Latest(), new("dn"))
+            .AddSdk(new(42, 42, 43), new Channel.Preview(), new("dn"))
+            .AddSdk(new(42, 42, 42), new Channel.Preview(), new("preview"));
 
         var outOfDate = PruneCommand.GetOutOfDateSdks(manifest);
 
@@ -24,8 +24,8 @@ public sealed class PruneTests
     public void OutOfDatePreview()
     {
         var manifest = Manifest.Empty
-            .AddSdk(SemVersion.Parse("8.0.0-preview.1", SemVersionStyles.Strict), Channel.Preview, new("dn"))
-            .AddSdk(SemVersion.Parse("8.0.0-rc.2", SemVersionStyles.Strict), Channel.Preview, new("dn"));
+            .AddSdk(SemVersion.Parse("8.0.0-preview.1", SemVersionStyles.Strict), new Channel.Preview(), new("dn"))
+            .AddSdk(SemVersion.Parse("8.0.0-rc.2", SemVersionStyles.Strict), new Channel.Preview(), new("dn"));
 
         var outOfDate = PruneCommand.GetOutOfDateSdks(manifest);
 

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -23,7 +23,7 @@ public sealed class SelectTests
     {
         var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Latest,
+            Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         var homeFs = env.Vfs;
@@ -32,7 +32,7 @@ public sealed class SelectTests
         Assert.True(homeFs.FileExists(defaultDotnet));
         result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Preview,
+            Channel = new Channel.Preview(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         var previewDotnet = DnvmEnv.GetSdkPath(defaultSdkDir) / Utilities.DotnetExeName;
@@ -64,7 +64,7 @@ public sealed class SelectTests
             [
                 new TrackedChannel
                     {
-                        ChannelName = Channel.Latest,
+                        ChannelName = new Channel.Latest(),
                         SdkDirName = dn
                     },
             ]

--- a/test/UnitTests/TrackTests.cs
+++ b/test/UnitTests/TrackTests.cs
@@ -17,7 +17,7 @@ public sealed class TrackTests
     [Fact]
     public Task LtsInstall() => RunWithServer(async (server, env) =>
     {
-        const Channel channel = Channel.Lts;
+        Channel channel = new Channel.Lts();
         var options = new CommandArguments.TrackArguments()
         {
             Channel = channel,
@@ -58,7 +58,7 @@ public sealed class TrackTests
     {
         var args = new CommandArguments.TrackArguments()
         {
-            Channel = Channel.Lts,
+            Channel = new Channel.Lts(),
             Verbose = true,
         };
         var homeFs = env.Vfs;
@@ -80,7 +80,7 @@ public sealed class TrackTests
 
         var args = new CommandArguments.TrackArguments()
         {
-            Channel = Channel.Preview,
+            Channel = new Channel.Preview(),
         };
         // Preview used to be isolated, but it shouldn't be anymore
         var sdkInstallDir = DnvmEnv.GetSdkPath(DnvmEnv.DefaultSdkDirName);
@@ -101,7 +101,7 @@ public sealed class TrackTests
         const string dirName = "sts";
         var args = new CommandArguments.TrackArguments()
         {
-            Channel = Channel.Sts,
+            Channel = new Channel.Sts(),
             SdkDir = dirName
         };
         // Check that the SDK is installed is isolated into the "sts" subdirectory
@@ -119,9 +119,9 @@ public sealed class TrackTests
     {
         // Default release index only contains an LTS release, so adding LTS and latest
         // should result in the same SDK being installed
-        var result = await TrackCommand.Run(env, _logger, new() { Channel = Channel.Latest });
+        var result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Latest() });
         Assert.Equal(TrackCommand.Result.Success , result);
-        result = await TrackCommand.Run(env, _logger, new() { Channel = Channel.Lts });
+        result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Lts() });
         Assert.Equal(TrackCommand.Result.Success , result);
 
         var ltsRelease = server.ReleasesIndexJson.Releases.Single(r => r.ReleaseType == "lts");
@@ -137,12 +137,12 @@ public sealed class TrackTests
         } ], manifest.InstalledSdks);
         Assert.Equal([
             new() {
-                ChannelName = Channel.Latest,
+                ChannelName = new Channel.Latest(),
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 InstalledSdkVersions = [ sdkVersion ]
             },
             new() {
-                ChannelName = Channel.Lts,
+                ChannelName = new Channel.Lts(),
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 InstalledSdkVersions = [ sdkVersion ]
             }

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -17,20 +17,20 @@ public sealed class UninstallTests
     {
         var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Latest,
+            Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Preview,
+            Channel = new Channel.Preview(),
             SdkDir = "preview"
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[0].LatestSdk, SemVersionStyles.Strict);
         var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[1].LatestSdk, SemVersionStyles.Strict);
         var expectedManifest = Manifest.Empty
-            .AddSdk(ltsVersion, Channel.Latest, DnvmEnv.DefaultSdkDirName)
-            .AddSdk(previewVersion, Channel.Preview, new SdkDirName("preview"));
+            .AddSdk(ltsVersion, new Channel.Latest(), DnvmEnv.DefaultSdkDirName)
+            .AddSdk(previewVersion, new Channel.Preview(), new SdkDirName("preview"));
         var manifest = await env.ReadManifest();
         Assert.Equal(expectedManifest, manifest);
         var unResult = await UninstallCommand.Run(env, _logger, new CommandArguments.UninstallArguments
@@ -40,7 +40,7 @@ public sealed class UninstallTests
         Assert.Equal(0, unResult);
         manifest = await env.ReadManifest();
         var previewOnly = Manifest.Empty
-            .AddSdk(previewVersion, Channel.Preview, new SdkDirName("preview"));
+            .AddSdk(previewVersion, new Channel.Preview(), new SdkDirName("preview"));
         previewOnly = previewOnly with {
             TrackedChannels = manifest.TrackedChannels
         };
@@ -63,12 +63,12 @@ public sealed class UninstallTests
     {
         var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Latest,
+            Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Preview,
+            Channel = new Channel.Preview(),
             SdkDir = "preview"
         });
         Assert.Equal(TrackCommand.Result.Success, result);

--- a/test/UnitTests/UntrackTests.cs
+++ b/test/UnitTests/UntrackTests.cs
@@ -21,7 +21,7 @@ public sealed class UntrackTests
     {
         var manifest = Manifest.Empty;
         var logger = new Logger(new TestConsole());
-        var result = UntrackCommand.RunHelper(Channel.Latest, manifest, logger);
+        var result = UntrackCommand.RunHelper(new Channel.Latest(), manifest, logger);
         Assert.True(result is UntrackCommand.Result.ChannelUntracked);
     }
 
@@ -30,10 +30,10 @@ public sealed class UntrackTests
     {
         var manifest = new Manifest
         {
-            TrackedChannels = [new TrackedChannel { ChannelName = Channel.Latest, SdkDirName = DnvmEnv.DefaultSdkDirName }]
+            TrackedChannels = [new TrackedChannel { ChannelName = new Channel.Latest(), SdkDirName = DnvmEnv.DefaultSdkDirName }]
         };
         var logger = new Logger(new TestConsole());
-        var result = UntrackCommand.RunHelper(Channel.Latest, manifest, logger);
+        var result = UntrackCommand.RunHelper(new Channel.Latest(), manifest, logger);
         if (result is UntrackCommand.Result.Success({} newManifest))
         {
             Assert.True(Assert.Single(newManifest.TrackedChannels).Untracked);
@@ -51,7 +51,7 @@ public sealed class UntrackTests
         var logger = new Logger(new TestConsole());
         var result = await TrackCommand.Run(testOptions.DnvmEnv, logger, new CommandArguments.TrackArguments
         {
-            Channel = Channel.Latest,
+            Channel = new Channel.Latest(),
             FeedUrl = mockServer.PrefixString
         });
         Assert.Equal(TrackCommand.Result.Success, result);

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -48,7 +48,7 @@ public sealed class UpdateTests
             [
                 new TrackedChannel
                     {
-                        ChannelName = Channel.Latest,
+                        ChannelName = new Channel.Latest(),
                         SdkDirName = sdkDir,
                         InstalledSdkVersions = [ new(42, 42, 142) ]
                     },
@@ -84,7 +84,7 @@ public sealed class UpdateTests
                 ReleaseVersion = installedVersion,
             }] ,
             TrackedChannels = [ new TrackedChannel {
-                ChannelName = Channel.Latest,
+                ChannelName = new Channel.Latest(),
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 InstalledSdkVersions = [ installedVersion ]
             } ]
@@ -92,7 +92,7 @@ public sealed class UpdateTests
         var releasesIndex = mockServer.ReleasesIndexJson;
         var results = UpdateCommand.FindPotentialUpdates(manifest, releasesIndex);
         var (channel, newestInstalled, newestAvailable, sdkDir) = results[0];
-        Assert.Equal(Channel.Latest, channel);
+        Assert.Equal(new Channel.Latest(), channel);
         Assert.Equal(new SemVersion(41, 0, 0), newestInstalled);
         Assert.Equal("42.42.42", newestAvailable!.LatestRelease);
         Assert.Equal(DnvmEnv.DefaultSdkDirName, sdkDir);
@@ -105,7 +105,7 @@ public sealed class UpdateTests
     {
         var baseVersion = new SemVersion(41, 0, 0);
         var upgradeVersion = new SemVersion(41, 0, 1);
-        const Channel channel = Channel.Latest;
+        Channel channel = new Channel.Latest();
         Setup(mockServer, baseVersion);
         var result = await TrackCommand.Run(env, _logger, new() {
             Channel = channel,
@@ -202,17 +202,17 @@ public sealed class UpdateTests
             Releases = [ltsRelease, stsRelease, ltsPreview, stsPreview]
         };
 
-        var actual = releasesIndex.GetChannelIndex(Channel.Latest);
+        var actual = releasesIndex.GetChannelIndex(new Channel.Latest());
         // STS is newest
         Assert.Equal(stsRelease, actual);
 
-        actual = releasesIndex.GetChannelIndex(Channel.Lts);
+        actual = releasesIndex.GetChannelIndex(new Channel.Lts());
         Assert.Equal(ltsRelease, actual);
 
-        actual = releasesIndex.GetChannelIndex(Channel.Sts);
+        actual = releasesIndex.GetChannelIndex(new Channel.Sts());
         Assert.Equal(stsRelease, actual);
 
-        actual = releasesIndex.GetChannelIndex(Channel.Preview);
+        actual = releasesIndex.GetChannelIndex(new Channel.Preview());
         // LTS preview is newest
         Assert.Equal(ltsPreview, actual);
     }
@@ -234,7 +234,7 @@ public sealed class UpdateTests
             Releases = [previewRelease]
         };
 
-        var actual = releasesIndex.GetChannelIndex(Channel.Preview);
+        var actual = releasesIndex.GetChannelIndex(new Channel.Preview());
         Assert.Equal(previewRelease, actual);
     }
 
@@ -242,14 +242,14 @@ public sealed class UpdateTests
     public Task DontUpdateUntracked() => TestUtils.RunWithServer(async (server, env) =>
     {
         var result = await TrackCommand.Run(env, _logger, new() {
-            Channel = Channel.Latest,
+            Channel = new Channel.Latest(),
             Verbose = true
         });
 
         Assert.Equal(TrackCommand.Result.Success, result);
 
         result = await TrackCommand.Run(env, _logger, new() {
-            Channel = Channel.Preview,
+            Channel = new Channel.Preview(),
             Verbose = true
         });
         Assert.Equal(TrackCommand.Result.Success, result);
@@ -260,9 +260,9 @@ public sealed class UpdateTests
     {
         // Default release index only contains an LTS release, so adding LTS and latest
         // should result in the same SDK being installed
-        var result = await TrackCommand.Run(env, _logger, new() { Channel = Channel.Latest });
+        var result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Latest() });
         Assert.Equal(TrackCommand.Result.Success , result);
-        result = await TrackCommand.Run(env, _logger, new() { Channel = Channel.Lts });
+        result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Lts() });
         Assert.Equal(TrackCommand.Result.Success , result);
 
         var oldRelease = server.ReleasesIndexJson.Releases.Single(r => r.ReleaseType == "lts");
@@ -288,12 +288,12 @@ public sealed class UpdateTests
             } ], manifest.InstalledSdks);
         Assert.Equal([
             new() {
-                ChannelName = Channel.Latest,
+                ChannelName = new Channel.Latest(),
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 InstalledSdkVersions = [ oldSdkVersion, newSdkVersion ]
             },
             new() {
-                ChannelName = Channel.Lts,
+                ChannelName = new Channel.Lts(),
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 InstalledSdkVersions = [ oldSdkVersion, newSdkVersion ]
             }


### PR DESCRIPTION
This allows you to track versions like '6.0' as though they were a named channel.