### PR TITLE
Fix download progress

### DIFF
--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -123,7 +123,7 @@ public static class InstallCommand
 
         logger.Log($"Downloading SDK {sdkVersion} for {ridString}");
 
-        var downloadError = await logger.Console.DownloadWithProgress(
+        var downloadError = await logger.DownloadWithProgress(
             Program.HttpClient,
             archivePath,
             link,


### PR DESCRIPTION
Change HttpClient.GetAsync call to pass ResponseHeadersRead. This allows for tracking download progress incrementally.