### PR TITLE
Fix installing daily builds

### DIFF
--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -1,5 +1,7 @@
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -102,7 +104,7 @@ public static partial class ManifestUtils
     /// Either reads a manifest in the current format, or reads a
     /// manifest in the old format and converts it to the new format.
     /// </summary>
-    public static async Task<Manifest> DeserializeNewOrOldManifest(string manifestSrc, string releasesUrl)
+    public static async Task<Manifest> DeserializeNewOrOldManifest(string manifestSrc, IEnumerable<string> releasesUrls)
     {
         var version = JsonSerializer.Deserialize<ManifestVersionOnly>(manifestSrc).Version;
         // Handle versions that don't need the release index to convert
@@ -116,8 +118,9 @@ public static partial class ManifestUtils
         {
             return manifest;
         }
+
         // Retrieve release index and convert
-        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(releasesUrl);
+        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(releasesUrls);
         return version switch
         {
             // The first version didn't have a version field

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -21,7 +21,7 @@ public class SelfInstallCommand
     private readonly Logger _logger;
     // Place to install dnvm
     private readonly CommandArguments.SelfInstallArguments _installArgs;
-    private readonly string _feedUrl;
+    private readonly IEnumerable<string> _feedUrls;
 
     public SelfInstallCommand(DnvmEnv env, Logger logger, CommandArguments.SelfInstallArguments args)
     {
@@ -32,11 +32,9 @@ public class SelfInstallCommand
         {
             _logger.LogLevel = LogLevel.Info;
         }
-        _feedUrl = _installArgs.FeedUrl ?? env.DotnetFeedUrl;
-        if (_feedUrl[^1] == '/')
-        {
-            _feedUrl = _feedUrl[..^1];
-        }
+        _feedUrls = _installArgs.FeedUrl is null
+            ? _env.DotnetFeedUrls
+            : new[] { _installArgs.FeedUrl.TrimEnd('/') };
     }
 
     public static async Task<Result> Run(Logger logger, CommandArguments.SelfInstallArguments args)
@@ -164,7 +162,7 @@ public class SelfInstallCommand
             _logger,
             channel,
             _installArgs.Force,
-            _feedUrl,
+            _feedUrls,
             sdkDirName);
 
         if (result is not TrackCommand.Result.Success)

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -20,7 +20,7 @@ public sealed partial class UpdateCommand
     private readonly DnvmEnv _env;
     private readonly Logger _logger;
     private readonly CommandArguments.UpdateArguments _args;
-    private readonly string _feedUrl;
+    private readonly IEnumerable<string> _feedUrls;
     private readonly string _releasesUrl;
 
     public UpdateCommand(DnvmEnv env, Logger logger, CommandArguments.UpdateArguments args)
@@ -31,11 +31,9 @@ public sealed partial class UpdateCommand
         {
             _logger.LogLevel = LogLevel.Info;
         }
-        _feedUrl = _args.FeedUrl ?? env.DotnetFeedUrl;
-        if (_feedUrl[^1] == '/')
-        {
-            _feedUrl = _feedUrl[..^1];
-        }
+        _feedUrls = _args.FeedUrl is not null
+            ? [ _args.FeedUrl.TrimEnd('/') ]
+            : env.DotnetFeedUrls;
         _releasesUrl = _args.DnvmReleasesUrl ?? env.DnvmReleasesUrl;
         _env = env;
     }
@@ -64,7 +62,7 @@ public sealed partial class UpdateCommand
         DotnetReleasesIndex releaseIndex;
         try
         {
-            releaseIndex = await DotnetReleasesIndex.FetchLatestIndex(_feedUrl);
+            releaseIndex = await DotnetReleasesIndex.FetchLatestIndex(_feedUrls);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.IO.Enumeration;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -17,6 +18,8 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 using Semver;
+using Serde;
+using Serde.Json;
 using Spectre.Console;
 using StaticCs;
 using Zio;
@@ -106,6 +109,16 @@ public static class SpectreUtil
 
 public static class Utilities
 {
+    public static Dictionary<TKey, TValue> DeserializeDictionary<TKey, TKeyWrap, TValue, TValueWrap>(string json)
+        where TKey : notnull
+        where TKeyWrap : IDeserialize<TKey>
+        where TValueWrap : IDeserialize<TValue>
+    {
+        return JsonSerializer.Deserialize<
+            Dictionary<TKey, TValue>,
+            DictWrap.DeserializeImpl<TKey, TKeyWrap, TValue, TValueWrap>>(json);
+    }
+
     public static readonly string ZipSuffix = Environment.OSVersion.Platform == PlatformID.Win32NT ? ".zip" : ".tar.gz";
 
     [UnsupportedOSPlatform("windows")]

--- a/src/dnvm/dnvm.csproj
+++ b/src/dnvm/dnvm.csproj
@@ -6,8 +6,7 @@
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
-    <!-- Skip symbol stripping on osx. The symbols are so broken that dsymutil crashes. -->
-    <StripSymbols Condition="!$([MSBuild]::IsOsPlatform('OSX'))">true</StripSymbols>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="Semver" Version="2.2.0" />
 
-    <PackageReference Include="Serde" Version="0.6.0-preview2" />
+    <PackageReference Include="Serde" Version="0.6.0-preview5" />
 
     <PackageReference Include="Spectre.Console" Version="0.46.0" />
     <PackageReference Include="StaticCs" Version="0.3.1" />

--- a/test/IntegrationTests/VersionCheck.cs
+++ b/test/IntegrationTests/VersionCheck.cs
@@ -11,7 +11,7 @@ public class VersionCheck
     [Fact]
     public async Task ReleasesEndpointIsUp()
     {
-        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(DnvmEnv.DefaultDotnetFeedUrl);
+        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(DnvmEnv.DefaultDotnetFeedUrls);
         Assert.NotEmpty(releasesIndex.Releases);
     }
 }

--- a/test/Shared/TestOptions.cs
+++ b/test/Shared/TestOptions.cs
@@ -20,7 +20,7 @@ public sealed class TestEnv : IDisposable
                 isPhysical: true,
                 getUserEnvVar: s => _envVars[s],
                 setUserEnvVar: (name, val) => _envVars[name] = val,
-                dotnetFeedUrl,
+                [ dotnetFeedUrl ],
                 releasesUrl);
     }
 

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -21,7 +21,7 @@ public sealed class ManifestTests
     ]
 }
 """;
-        var parsed = await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrl);
+        var parsed = await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrls);
         Assert.Equal("dn", parsed!.CurrentSdkDir.Name);
     });
 
@@ -88,7 +88,7 @@ public sealed class ManifestTests
             ]
         });
 
-        var v5 = (await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrl))!;
+        var v5 = (await ManifestUtils.DeserializeNewOrOldManifest(manifest, env.DotnetFeedUrls))!;
         Assert.Equal(new Channel.Latest(), v5.RegisteredChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[0].SdkVersion)).ChannelName);
         Assert.Equal(new Channel.Preview(), v5.RegisteredChannels.Single(c => c.InstalledSdkVersions.Contains(v5.InstalledSdks[1].SdkVersion)).ChannelName);
     });


### PR DESCRIPTION
Normally we rely on the .NET releases index to find both the version information for the requested SDK and the download URL. In the case of daily builds, none of that information is published to an index. Therefore we need to use other resources. For the URL, there is a known pattern that is implemented by dotnet-install.sh that we copy. For the version information, there is an undocumented `productCommit-{RID}.json` file that appears to contain the necessary information. Together, these items should allow us to install and uninstall daily builds.