### PR TITLE
Fix tracking channels with no builds

### DIFF
--- a/src/dnvm/Channel.cs
+++ b/src/dnvm/Channel.cs
@@ -1,4 +1,5 @@
 
+using System.Globalization;
 using Semver;
 using Serde;
 using StaticCs;
@@ -14,23 +15,6 @@ public static class Channels
         Channel.Sts => "The latest version in Short-Term support",
         Channel.Latest => "The latest supported version from either the LTS or STS support channels.",
         Channel.Preview => "The latest preview version",
-    };
-
-    public static string GetLowerName(this Channel c) => c switch
-    {
-        Channel.Versioned v => v.ToString(),
-        Channel.Lts => "lts",
-        Channel.Sts => "sts",
-        Channel.Latest => "latest",
-        Channel.Preview => "preview",
-    };
-    public static string GetDisplayName(this Channel c) => c switch
-    {
-        Channel.Versioned v => v.ToString(),
-        Channel.Lts => "LTS",
-        Channel.Sts => "STS",
-        Channel.Latest => "Latest",
-        Channel.Preview => "Preview",
     };
 }
 
@@ -64,35 +48,31 @@ public abstract partial record Channel
 
 partial record Channel : ISerialize<Channel>, ISerialize
 {
-    protected abstract void Serialize(ISerializer serializer);
-    void ISerialize<Channel>.Serialize(Channel channel, ISerializer serializer) => Serialize(serializer);
+    public abstract string GetDisplayName();
+    public sealed override string ToString() => GetDisplayName();
+    public string GetLowerName() => GetDisplayName().ToLowerInvariant();
+    void ISerialize<Channel>.Serialize(Channel channel, ISerializer serializer)
+        => serializer.SerializeString(GetLowerName());
 
     partial record Versioned
     {
-        public override string ToString() => $"{Major}.{Minor}";
-
-        protected override void Serialize(ISerializer serializer)
-            => serializer.SerializeString(this.ToString());
+        public override string GetDisplayName() => $"{Major}.{Minor}";
     }
     partial record Lts : Channel
     {
-        protected override void Serialize(ISerializer serializer)
-            => serializer.SerializeString("lts");
+        public override string GetDisplayName() => "LTS";
     }
     partial record Sts : Channel
     {
-        protected override void Serialize(ISerializer serializer)
-            => serializer.SerializeString("sts");
+        public override string GetDisplayName() => "STS";
     }
     partial record Latest : Channel
     {
-        protected override void Serialize(ISerializer serializer)
-            => serializer.SerializeString("latest");
+        public override string GetDisplayName() => "Latest";
     }
     partial record Preview : Channel
     {
-        protected override void Serialize(ISerializer serializer)
-            => serializer.SerializeString("preview");
+        public override string GetDisplayName() => "Preview";
     }
 }
 

--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -71,6 +71,8 @@ public partial record DotnetReleasesIndex
 [GenerateSerde]
 public partial record DotnetReleasesIndex
 {
+    public static readonly DotnetReleasesIndex Empty = new() { Releases = [ ] };
+
     [SerdeMemberOptions(Rename = "releases-index")]
     public required ImmutableArray<ChannelIndex> Releases { get; init; }
 

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -12,6 +12,7 @@ namespace Dnvm.Test;
 public sealed class MockServer : IAsyncDisposable
 {
     public static readonly SemVersion DefaultLtsVersion = new SemVersion(42, 42, 42);
+    public static readonly SemVersion DefaultPreviewVersion = SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict);
 
     private readonly HttpListener _listener;
     private readonly TaskScope _scope;
@@ -52,7 +53,7 @@ public sealed class MockServer : IAsyncDisposable
             }
         }
         RegisterReleaseVersion(DefaultLtsVersion, "lts", "active");
-        RegisterReleaseVersion(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), "sts", "preview");
+        RegisterReleaseVersion(DefaultPreviewVersion, "sts", "preview");
         DnvmReleases = new()
         {
             LatestVersion = new()


### PR DESCRIPTION
It's common for some channels (e.g., preview) to not have builds for a period of time when the previous channel has gone out of support, but the new one has not had any releases yet. Tracking shouldn't depend on installing an SDK, so there's no reason we can't allow tracking to proceed.

Fixes #135