### PR TITLE
Fix 'track' output and formatting

### DIFF
--- a/src/dnvm/CommandLineArguments.cs
+++ b/src/dnvm/CommandLineArguments.cs
@@ -37,11 +37,9 @@ public abstract record CommandArguments
         /// Answer yes to every question or use the defaults.
         /// </summary>
         public bool Yes { get; init; } = false;
-        public bool Prereqs { get; init; } = false;
         /// <summary>
         /// When specified, install the SDK into a separate directory with the given name,
-        /// translated to lower-case. Preview releases are installed into a directory named 'preview'
-        /// by default.
+        /// translated to lower-case.
         /// </summary>
         public string? SdkDir { get; init; } = null;
     }
@@ -128,7 +126,7 @@ public sealed record class CommandLineArguments(CommandArguments Command)
             var track = syntax.DefineCommand("track", ref commandName, "Start tracking a new channel");
             if (track.IsActive)
             {
-                Channel channel = new Channel.Latest();
+                Channel? channel = null;
                 bool verbose = default;
                 bool force = default;
                 bool yes = false;
@@ -141,16 +139,14 @@ public sealed record class CommandLineArguments(CommandArguments Command)
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
                 syntax.DefineOption("feed-url", ref feedUrl, $"Set the feed URL to download the SDK from.");
                 syntax.DefineOption("s|sdkDir", ref sdkDir, "Track the channel in a separate directory with the given name.");
-                syntax.DefineParameter("channel", ref channel, ChannelParse,
-                    $"Track the channel specified. Defaults to '{channel.ToString().ToLowerInvariant()}'.");
+                syntax.DefineParameter("channel", ref channel, ChannelParse, $"Track the channel specified.");
 
                 command = new CommandArguments.TrackArguments
                 {
-                    Channel = channel,
+                    Channel = channel.Unwrap(),
                     Verbose = verbose,
                     Force = force,
                     Yes = yes,
-                    Prereqs = prereqs,
                     FeedUrl = feedUrl,
                     SdkDir = sdkDir,
                 };
@@ -308,7 +304,7 @@ public sealed record class CommandLineArguments(CommandArguments Command)
 
     private static Channel ChannelParse(string channel)
     {
-        var scalarDeserializer = new ScalarDeserializer(channel);
+        var scalarDeserializer = new ScalarDeserializer(channel.ToLowerInvariant());
         try
         {
             var result = Channel.Deserialize(ref scalarDeserializer);

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -157,13 +157,14 @@ public class SelfInstallCommand
             return Result.SelfInstallFailed;
         }
 
-        var result = await TrackCommand.InstallLatestFromChannel(
-            _env,
-            _logger,
-            channel,
-            _installArgs.Force,
-            _feedUrls,
-            sdkDirName);
+        var result = await TrackCommand.Run(_env, _logger, new CommandArguments.TrackArguments() {
+            Channel = channel,
+            Force = _installArgs.Force,
+            Verbose = _installArgs.Verbose,
+            FeedUrl = _installArgs.FeedUrl,
+            SdkDir = sdkDirName.Name,
+            Yes = _installArgs.Yes
+        });
 
         if (result is not TrackCommand.Result.Success)
         {

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -297,6 +297,14 @@ public static class Utilities
         return null;
     }
 
+    public static T Unwrap<T>(this T? t, [CallerArgumentExpression(parameterName: nameof(t))] string? expr = null) where T : class
+    {
+        if (t is null)
+        {
+            throw new NullReferenceException("Unexpected null value in expression: " + (expr ?? "(null)"));
+        }
+        return t;
+    }
 }
 
 [Closed]

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -56,4 +56,16 @@ public sealed class CommandLineTests
             "badversion"
         ]));
     }
+
+    [Fact]
+    public void TrackMixedCase()
+    {
+        var options = CommandLineArguments.Parse([
+            "track",
+            "lTs"
+        ]);
+        Assert.True(options.Command is CommandArguments.TrackArguments {
+            Channel: Channel.Lts
+        });
+    }
 }


### PR DESCRIPTION
The output is now using the display names, but 'track' will accept any lower-case equivalent channel name when tracking.

Fixes #134