### PR TITLE
Slightly more robust parameter parsing

### DIFF
--- a/src/dnvm/CommandLine/ArgumentParser.cs
+++ b/src/dnvm/CommandLine/ArgumentParser.cs
@@ -110,6 +110,7 @@ namespace Internal.CommandLine
 
         public bool TryParseParameter<T>(string diagnosticName,
             Func<string, T> valueConverter,
+            bool isRequired,
             [MaybeNullWhen(false)] out T value)
         {
             foreach (var token in _tokens)
@@ -124,6 +125,12 @@ namespace Internal.CommandLine
                 return true;
             }
 
+            if (isRequired)
+            {
+                var message = string.Format(Strings.ParameterRequiresValueFmt, diagnosticName);
+                throw new ArgumentSyntaxException(message);
+            }
+            
             value = default;
             return false;
         }
@@ -131,11 +138,12 @@ namespace Internal.CommandLine
         public bool TryParseParameterList<T>(
             string diagnosticName,
             Func<string, T> valueConverter,
+            bool isRequired,
             [NotNullWhen(true)] out IReadOnlyList<T>? values)
         {
             var result = new List<T>();
 
-            while (TryParseParameter(diagnosticName, valueConverter, out T? value))
+            while (TryParseParameter(diagnosticName, valueConverter, isRequired, out T? value))
             {
                 result.Add(value);
             }

--- a/src/dnvm/CommandLine/ArgumentSyntax.cs
+++ b/src/dnvm/CommandLine/ArgumentSyntax.cs
@@ -211,7 +211,7 @@ namespace Internal.CommandLine
             return optionList;
         }
 
-        public Argument<T> DefineParameter<T>(string name, T defaultValue, Func<string, T> valueConverter)
+        public Argument<T> DefineParameter<T>(string name, T defaultValue, Func<string, T> valueConverter, bool isRequired)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException(Strings.NameMissing, "name");
@@ -239,7 +239,7 @@ namespace Internal.CommandLine
 
             try
             {
-                if (Parser.TryParseParameter(parameter.GetDisplayName(), valueConverter, out T? value))
+                if (Parser.TryParseParameter(parameter.GetDisplayName(), valueConverter, isRequired, out T? value))
                     parameter.SetValue(value);
             }
             catch (ArgumentSyntaxException ex)
@@ -272,7 +272,7 @@ namespace Internal.CommandLine
 
             try
             {
-                if (Parser.TryParseParameterList(parameterList.GetDisplayName(), valueConverter, out IReadOnlyList<T>? values))
+                if (Parser.TryParseParameterList(parameterList.GetDisplayName(), valueConverter, false, out IReadOnlyList<T>? values))
                     parameterList.SetValue(values);
             }
             catch (ArgumentSyntaxException ex)

--- a/src/dnvm/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/dnvm/CommandLine/ArgumentSyntax_Definers.cs
@@ -183,22 +183,22 @@ namespace Internal.CommandLine
 
         public Argument<string> DefineParameter(string name, string defaultValue)
         {
-            return DefineParameter(name, defaultValue, s_stringParser);
+            return DefineParameter(name, defaultValue, s_stringParser, false);
         }
 
         public Argument<bool> DefineParameter(string name, bool defaultValue)
         {
-            return DefineParameter(name, defaultValue, s_booleanParser);
+            return DefineParameter(name, defaultValue, s_booleanParser, false);
         }
 
         public Argument<int> DefineParameter(string name, int defaultValue)
         {
-            return DefineParameter(name, defaultValue, s_int32Parser);
+            return DefineParameter(name, defaultValue, s_int32Parser, false);
         }
 
         public Argument<T> DefineParameter<T>(string name, ref T value, Func<string, T> valueConverter, string help)
         {
-            var parameter = DefineParameter(name, value, valueConverter);
+            var parameter = DefineParameter(name, value, valueConverter, true);
             parameter.Help = help;
 
             value = parameter.Value;

--- a/src/dnvm/CommandLine/Strings.cs
+++ b/src/dnvm/CommandLine/Strings.cs
@@ -16,6 +16,7 @@ internal static class Strings
     public static readonly string UnknownCommandFmt = "unknown command '{0}'";
     public static readonly string UnmatchedQuoteFmt = "Unmatched quote at position {0}.";
     public static readonly string OptionRequiresValueFmt = "option {0} requires a value";
+    public static readonly string ParameterRequiresValueFmt = "Parameter {0} requires a value";
     public static readonly string ParameterAlreadyDefinedFmt = "Parameter '{0}' is already defined.";
     public static readonly string CannotDefineMultipleParameterLists = "Cannot define multiple parameter lists.";
     public static readonly string ParametersCannotBeDefinedAfterLists = "Parameters cannot be defined after parameter lists.";


### PR DESCRIPTION
When doing

```text
dvnm install
```

the following exception is raised

```text
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Dnvm.InstallCommand.<Run>d__1.MoveNext() + 0x198
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x24
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0x100
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task, ConfigureAwaitOptions) + 0x68
   at Dnvm.Program.<Dnvm>d__3.MoveNext() + 0x2f0
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x24
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0x100
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task, ConfigureAwaitOptions) + 0x68
   at Dnvm.Program.<Main>d__2.MoveNext() + 0x2cc
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x24
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0x100
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task, ConfigureAwaitOptions) + 0x68
   at Dnvm.Program.<Main>(String[] args) + 0x3c
   at dnvm!<BaseAddress>+0x557538
```

The code tries to access `options.SdkVersion.Major` while `SdkVersion` is null.

With this change you get

`error: Parameter <version> requires a value`

There might be a few edge cases I haven't been able to cover given the limited amount of time I had available to fix this. Sorry for that.
