### PR TITLE
Move more code to Serde.CmdLine

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Serde" Version="0.7.0-preview1" />
+    <PackageVersion Include="Serde" Version="0.7.0-preview2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.46.0" />
     <PackageVersion Include="StaticCs" Version="0.3.1" />

--- a/src/Serde.CmdLine/Attributes.cs
+++ b/src/Serde.CmdLine/Attributes.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace Serde.CmdLine;
 
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field,
+    AllowMultiple = false,
+    Inherited = false)]
 public sealed class CommandOptionAttribute(string flagNames) : Attribute
 {
     public string FlagNames { get; } = flagNames;
@@ -10,11 +13,23 @@ public sealed class CommandOptionAttribute(string flagNames) : Attribute
     public string? Description { get; init; } = null;
 }
 
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field,
+    AllowMultiple = false,
+    Inherited = false)]
 public sealed class CommandParameterAttribute(int ordinal, string name) : Attribute
 {
     public int Ordinal { get; } = ordinal;
 
     public string Name { get; } = name;
 
+    public string? Description { get; init; } = null;
+}
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class,
+    AllowMultiple = false,
+    Inherited = false)]
+public sealed class CommandAttribute(string name) : Attribute
+{
+    public string Name { get; } = name;
     public string? Description { get; init; } = null;
 }

--- a/src/Serde.CmdLine/CmdLine.cs
+++ b/src/Serde.CmdLine/CmdLine.cs
@@ -15,7 +15,8 @@ public static class CmdLine
         var cmd =  T.Deserialize(deserializer);
         if (throwOnHelpRequested && deserializer.HelpRequested)
         {
-            throw new HelpRequestedException(deserializer.HelpText);
+            var helpText = Deserializer.GetHelpText(SerdeInfoProvider.GetInfo<T>());
+            throw new HelpRequestedException(helpText);
         }
         return cmd;
     }
@@ -45,14 +46,16 @@ public static class CmdLine
             cmd = T.Deserialize(deserializer);
             if (options.ThrowOnHelpRequested && deserializer.HelpRequested)
             {
-                console.Write(deserializer.HelpText);
+                var helpText = Deserializer.GetHelpText(SerdeInfoProvider.GetInfo<T>());
+                console.Write(helpText);
             }
             return true;
         }
         catch (InvalidDeserializeValueException e) when (options.HandleErrors)
         {
             console.WriteLine("error: " + e.Message);
-            console.Write(deserializer.HelpText);
+            var helpText = Deserializer.GetHelpText(SerdeInfoProvider.GetInfo<T>());
+            console.Write(helpText);
         }
         cmd = default!;
         return false;

--- a/src/Serde.CmdLine/UnionSerdeInfo.cs
+++ b/src/Serde.CmdLine/UnionSerdeInfo.cs
@@ -1,0 +1,30 @@
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Serde;
+
+namespace Serde.CmdLine;
+
+public sealed record UnionSerdeInfo(
+    string Name,
+    IList<CustomAttributeData> Attributes,
+    IEnumerable<ISerdeInfo> CaseInfos) : IUnionSerdeInfo
+{
+    int ISerdeInfo.FieldCount => 0;
+
+    public IList<CustomAttributeData> GetFieldAttributes(int index) => throw GetOOR(index);
+
+    public ReadOnlySpan<byte> GetFieldName(int index) => throw GetOOR(index);
+
+    public string GetFieldStringName(int index) => throw GetOOR(index);
+
+    public int TryGetIndex(ReadOnlySpan<byte> name) => IDeserializeType.IndexNotFound;
+
+    ISerdeInfo ISerdeInfo.GetFieldInfo(int index) => throw GetOOR(index);
+
+    private IndexOutOfRangeException GetOOR(int index)
+    {
+        return new IndexOutOfRangeException($"Type {Name} has no fields, but tried to access index {index}");
+    }
+}

--- a/src/Serde.CmdLine/Utils.cs
+++ b/src/Serde.CmdLine/Utils.cs
@@ -9,3 +9,9 @@ internal static class NullableExt
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static U Map<T, U>(this T t, Func<T, U> f) => f(t);
 }
+
+internal static class StringExt
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string Prepend(this string s, string prefix) => prefix + s;
+}

--- a/src/dnvm/Channel.cs
+++ b/src/dnvm/Channel.cs
@@ -1,5 +1,8 @@
 
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using Semver;
 using Serde;
 using StaticCs;
@@ -51,6 +54,9 @@ partial record Channel : ISerialize<Channel>
     public abstract string GetDisplayName();
     public sealed override string ToString() => GetDisplayName();
     public string GetLowerName() => GetDisplayName().ToLowerInvariant();
+
+    static ISerdeInfo ISerdeInfoProvider.SerdeInfo { get; } = SerdeInfo.MakePrimitive(nameof(Channel));
+
     void ISerialize<Channel>.Serialize(Channel channel, ISerializer serializer)
         => serializer.SerializeString(GetLowerName());
 
@@ -79,8 +85,10 @@ partial record Channel : ISerialize<Channel>
 partial record Channel : IDeserialize<Channel>
 {
     public static Channel Deserialize(IDeserializer deserializer)
+        => FromString(StringWrap.Deserialize(deserializer));
+
+    public static Channel FromString(string str)
     {
-        var str = StringWrap.Deserialize(deserializer);
         switch (str)
         {
             case "lts": return new Lts();

--- a/src/dnvm/ScalarDeserializer.cs
+++ b/src/dnvm/ScalarDeserializer.cs
@@ -65,9 +65,9 @@ public struct ScalarDeserializer(string s) : IDeserializer
     public T DeserializeU64<T>(IDeserializeVisitor<T> v)
         => v.VisitU64(ulong.Parse(s));
 
-    IDeserializeCollection IDeserializer.DeserializeCollection(TypeInfo typeInfo)
+    IDeserializeCollection IDeserializer.DeserializeCollection(ISerdeInfo typeInfo)
         => throw new InvalidDeserializeValueException("Found enumerable, expected scalar");
 
-    IDeserializeType IDeserializer.DeserializeType(TypeInfo typeInfo)
+    IDeserializeType IDeserializer.DeserializeType(ISerdeInfo typeInfo)
         => throw new InvalidDeserializeValueException("Found type, expected scalar");
 }

--- a/src/dnvm/SerdeWraps/SdkDirNameProxy.cs
+++ b/src/dnvm/SerdeWraps/SdkDirNameProxy.cs
@@ -1,0 +1,20 @@
+
+using Serde;
+
+namespace Dnvm;
+
+internal sealed class SdkDirNameProxy : ISerialize<SdkDirName>, IDeserialize<SdkDirName>
+{
+    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(nameof(SdkDirName));
+
+    public static SdkDirName Deserialize(IDeserializer deserializer)
+    {
+        var str = StringWrap.Deserialize(deserializer);
+        return new SdkDirName(str);
+    }
+
+    public void Serialize(SdkDirName value, ISerializer serializer)
+    {
+        serializer.SerializeString(value.Name);
+    }
+}

--- a/src/dnvm/SerdeWraps/SdkDirNameProxy.cs
+++ b/src/dnvm/SerdeWraps/SdkDirNameProxy.cs
@@ -3,15 +3,15 @@ using Serde;
 
 namespace Dnvm;
 
+/// <summary>
+/// Serializes the <see cref="SdkDirName.Name"/> directly as a string.
+/// </summary>
 internal sealed class SdkDirNameProxy : ISerialize<SdkDirName>, IDeserialize<SdkDirName>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(nameof(SdkDirName));
 
     public static SdkDirName Deserialize(IDeserializer deserializer)
-    {
-        var str = StringWrap.Deserialize(deserializer);
-        return new SdkDirName(str);
-    }
+        => new SdkDirName(StringWrap.Deserialize(deserializer));
 
     public void Serialize(SdkDirName value, ISerializer serializer)
     {

--- a/src/dnvm/SerdeWraps/SemVersionSerdeWrap.cs
+++ b/src/dnvm/SerdeWraps/SemVersionSerdeWrap.cs
@@ -7,9 +7,9 @@ namespace Dnvm;
 /// <summary>
 /// Serializes as a string.
 /// </summary>
-internal readonly record struct SemVersionSerdeWrap(SemVersion Value) : ISerialize<SemVersion>, IDeserialize<SemVersion>
+internal readonly record struct SemVersionSerdeWrap : ISerialize<SemVersion>, IDeserialize<SemVersion>
 {
-    public static SemVersionSerdeWrap Create(SemVersion value) => new(value);
+    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(nameof(SemVersion));
 
     public static SemVersion Deserialize(IDeserializer deserializer)
     {
@@ -19,11 +19,6 @@ internal readonly record struct SemVersionSerdeWrap(SemVersion Value) : ISeriali
             return version;
         }
         throw new InvalidDeserializeValueException($"Version string '{str}' is not a valid SemVersion.");
-    }
-
-    public void Serialize(ISerializer serializer)
-    {
-        serializer.SerializeString(Value.ToString());
     }
 
     public void Serialize(SemVersion value, ISerializer serializer)

--- a/test/Serde.CmdLine.Test/SubCommandTests.cs
+++ b/test/Serde.CmdLine.Test/SubCommandTests.cs
@@ -1,0 +1,92 @@
+
+using System.IO;
+using System.Linq;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Serde.CmdLine;
+
+public sealed partial class SubCommandTests
+{
+    [Fact]
+    public void NoSubCommand()
+    {
+        string[] testArgs = [ "-v" ];
+        var cmd = CmdLine.ParseRaw<TopCommand>(testArgs);
+        Assert.Equal(new TopCommand { Verbose = true, SubCommand = null }, cmd);
+    }
+
+    [Fact]
+    public void FirstCommand()
+    {
+        string[] testArgs = [ "-v", "first" ];
+        var cmd = CmdLine.ParseRaw<TopCommand>(testArgs);
+        Assert.Equal(new TopCommand { Verbose = true, SubCommand = new SubCommand.FirstCommand() }, cmd);
+    }
+
+    [Fact]
+    public void TopLevelHelp()
+    {
+        string[] testArgs = [ "-h" ];
+        var testConsole = new TestConsole();
+        Assert.True(CmdLine.TryParse<TopCommand>(testArgs, testConsole, out _));
+        var text = """
+Usage: TopCommand [-v | --verbose] <command>
+
+Options:
+    -v, --verbose
+
+Commands:
+    first
+    second
+
+""";
+        Assert.Equal(text.NormalizeLineEndings(), testConsole.Output);
+    }
+
+    [GenerateDeserialize]
+    private partial record TopCommand
+    {
+        [CommandOption("-v|--verbose")]
+        public bool? Verbose { get; init; }
+
+        [Command("command")]
+        public SubCommand? SubCommand { get; init; }
+    }
+
+    private partial record SubCommand : IDeserialize<SubCommand>
+    {
+        private SubCommand() { }
+
+        public static ISerdeInfo SerdeInfo { get; } = new UnionSerdeInfo(
+            typeof(SubCommand).ToString(),
+            typeof(SubCommand).GetCustomAttributesData(),
+            [
+                SerdeInfoProvider.GetInfo<FirstCommandProxy>(),
+                SerdeInfoProvider.GetInfo<SecondCommandProxy>()
+            ]);
+
+        static SubCommand IDeserialize<SubCommand>.Deserialize(IDeserializer deserializer)
+        {
+            var subCmd = StringWrap.Deserialize(deserializer);
+            return subCmd switch
+            {
+                "first" => new FirstCommand(),
+                "second" => new SecondCommand(),
+                _ => throw new InvalidDeserializeValueException($"Unknown subcommand '{subCmd}'.")
+            };
+        }
+
+        // Use proxies for deserialization as we want to avoid exposing deserialization for the
+        // union types themselves. We want all deserialization to go through the parent type.
+        [GenerateDeserialize(ThroughType = typeof(FirstCommand))]
+        private sealed partial record FirstCommandProxy;
+        [GenerateDeserialize(ThroughType = typeof(SecondCommand))]
+        private sealed partial record SecondCommandProxy;
+
+        [Command("first")]
+        public sealed partial record FirstCommand : SubCommand;
+        [Command("second")]
+        public sealed partial record SecondCommand : SubCommand;
+    }
+}


### PR DESCRIPTION
Moves more argument parsing over to Serde.CmdLine and adds support for unions using the new Serde ISerdeInfo interface.

Also builds help text entirely out of ISerdeInfoProvider, which allows it to be built separate from deserialization, fully statically.