### PR TITLE
Upgrade arm64 to use noble packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,12 +35,14 @@ jobs:
       run: |
         sudo dpkg --add-architecture arm64
         sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+        Types: deb
+        URIs: http://ports.ubuntu.com/ubuntu-ports/
+        Suites: noble noble-updates noble-backports
+        Components: main universe restricted multiverse
+        Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+        Architectures: arm64
         EOF'
-        sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-        sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
+        sudo sed -i -e 's/\(Signed-By:.*$\)/\1\nArchitectures: amd64 arm64/g' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt update
         sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
     - uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu CI runners have been upgraded to noble, old packages don't work anymore.