### PR TITLE
Add 'restore' command to Dnvm

### DIFF
--- a/src/dnvm/DotnetReleasesIndex.cs
+++ b/src/dnvm/DotnetReleasesIndex.cs
@@ -39,7 +39,7 @@ public partial record DotnetReleasesIndex
     public ChannelIndex? GetChannelIndex(Channel c)
     {
         (ChannelIndex Release, SemVersion Version)? latestRelease = null;
-        foreach (var release in this.Releases)
+        foreach (var release in this.ChannelIndices)
         {
             var supportPhase = release.SupportPhase.ToLowerInvariant();
             var releaseType = release.ReleaseType.ToLowerInvariant();
@@ -71,10 +71,10 @@ public partial record DotnetReleasesIndex
 [GenerateSerde]
 public partial record DotnetReleasesIndex
 {
-    public static readonly DotnetReleasesIndex Empty = new() { Releases = [ ] };
+    public static readonly DotnetReleasesIndex Empty = new() { ChannelIndices = [ ] };
 
     [SerdeMemberOptions(Rename = "releases-index")]
-    public required ImmutableArray<ChannelIndex> Releases { get; init; }
+    public required ImmutableArray<ChannelIndex> ChannelIndices { get; init; }
 
     [GenerateSerde]
     [SerdeTypeOptions(MemberFormat = MemberFormat.KebabCase)]

--- a/src/dnvm/ManifestSchema/ManifestV3.cs
+++ b/src/dnvm/ManifestSchema/ManifestV3.cs
@@ -2,9 +2,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Dnvm;
 using Serde;
 using StaticCs.Collections;
+
+namespace Dnvm;
 
 [GenerateSerde]
 public sealed partial record ManifestV3

--- a/src/dnvm/ManifestSchema/ManifestV5.cs
+++ b/src/dnvm/ManifestSchema/ManifestV5.cs
@@ -77,7 +77,7 @@ public static partial class ManifestV5Convert
                 return channelReleaseIndex;
             }
 
-            var channelRelease = releasesIndex.Releases.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
+            var channelRelease = releasesIndex.ChannelIndices.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
             channelReleaseIndex = JsonSerializer.Deserialize<ChannelReleaseIndex>(
                 await Program.HttpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
             channelMemo[majorMinor] = channelReleaseIndex;

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -59,6 +59,10 @@ public static class Program
             CommandArguments.UntrackArguments o => await UntrackCommand.Run(env, logger, o),
             CommandArguments.UninstallArguments o => await UninstallCommand.Run(env, logger, o),
             CommandArguments.PruneArguments args => await PruneCommand.Run(env, logger, args),
+            CommandArguments.RestoreArguments => await RestoreCommand.Run(env, logger) switch {
+                Result<SemVersion, RestoreCommand.Error>.Ok => 0,
+                Result<SemVersion, RestoreCommand.Error>.Err x => (int)x.Value,
+            },
 
             CommandArguments.SelfInstallArguments => throw ExceptionUtilities.Unreachable,
         };

--- a/src/dnvm/RestoreCommand.cs
+++ b/src/dnvm/RestoreCommand.cs
@@ -1,0 +1,389 @@
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Semver;
+using Serde;
+using Serde.Json;
+using Spectre.Console;
+using StaticCs;
+using Zio;
+using RollForwardOptions =  Dnvm.GlobalJsonSubset.SdkSubset.RollForwardOptions;
+
+namespace Dnvm;
+
+[GenerateDeserialize]
+internal sealed partial record GlobalJsonSubset
+{
+    public SdkSubset? Sdk { get; init; }
+
+    [GenerateDeserialize]
+    public sealed partial record SdkSubset
+    {
+        [SerdeMemberOptions(DeserializeProxy = typeof(NullableRefProxy.Deserialize<SemVersion, SemVersionProxy>))]
+        public SemVersion? Version { get; init; }
+        public RollForwardOptions? RollForward { get; init; }
+        public bool? AllowPrerelease { get; init; }
+
+        [GenerateDeserialize]
+        [Closed]
+        public enum RollForwardOptions
+        {
+            /// <summary>
+            /// Uses the specified version.
+            ///
+            /// If not found, rolls forward to the latest patch level.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            Patch,
+            /// <summary>
+            /// Uses the latest patch level for the specified major, minor, and feature band.
+            ///
+            /// If not found, rolls forward to the next higher feature band within the same
+            /// major/minor and uses the latest patch level for that feature band.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            Feature,
+            /// <summary>
+            /// Uses the latest patch level for the specified major, minor, and feature band.
+            ///
+            /// If not found, rolls forward to the next higher feature band within the same
+            /// major/minor version and uses the latest patch level for that feature band.
+            ///
+            /// If not found, rolls forward to the next higher minor and feature band within the
+            /// same major and uses the latest patch level for that feature band.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            Minor,
+            /// <summary>
+            /// Uses the latest patch level for the specified major, minor, and feature band.
+            ///
+            /// If not found, rolls forward to the next higher feature band within the same
+            /// major/minor version and uses the latest patch level for that feature band.
+            ///
+            /// If not found, rolls forward to the next higher minor and feature band within the
+            /// same major and uses the latest patch level for that feature band.
+            ///
+            /// If not found, rolls forward to the next higher major, minor, and feature band
+            /// and uses the latest patch level for that feature band.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            Major,
+            /// <summary>
+            /// Uses the latest installed patch level that matches the requested major, minor,
+            /// and feature band with a patch level that's greater than or equal to the
+            /// specified value.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            LatestPatch,
+            /// <summary>
+            /// Uses the highest installed feature band and patch level that matches the
+            /// requested major and minor with a feature band and patch level that's greater
+            /// than or equal to the specified value.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            LatestFeature,
+            /// <summary>
+            /// Uses the highest installed minor, feature band, and patch level that matches the
+            /// requested major with a minor, feature band, and patch level that's greater than
+            /// or equal to the specified value.
+            ///
+            /// If not found, fails.
+            /// </summary>
+            LatestMinor,
+            /// <summary>
+            /// Uses the highest installed .NET SDK with a version that's greater than or equal
+            /// to the specified value.
+            ///
+            /// If not found, fail.
+            /// </summary>
+            LatestMajor,
+            /// <summary>
+            /// Doesn't roll forward. An exact match is required.
+            /// </summary>
+            Disable,
+        }
+    }
+}
+
+public static partial class RestoreCommand
+{
+    public enum Error
+    {
+        NoGlobalJson = 1,
+        IoError = 2,
+        NoSdkSection = 3,
+        NoVersion = 4,
+        CouldntFetchReleaseIndex = 5,
+        CantFindRequestedVersion = 6,
+    }
+
+    public static async Task<Result<SemVersion, Error>> Run(DnvmEnv env, Logger logger)
+    {
+        UPath? globalJsonPathOpt = null;
+        UPath cwd = env.Cwd;
+        while (true)
+        {
+            var testPath = cwd / "global.json";
+            if (env.CwdFs.FileExists(testPath))
+            {
+                globalJsonPathOpt = testPath;
+                break;
+            }
+            if (cwd == UPath.Root)
+            {
+                break;
+            }
+            cwd = cwd.GetDirectory();
+        }
+
+        if (globalJsonPathOpt is not {} globalJsonPath)
+        {
+            logger.Error("No global.json found in the current directory or any of its parents.");
+            return Error.NoGlobalJson;
+        }
+
+        GlobalJsonSubset json;
+        try
+        {
+            var text = env.CwdFs.ReadAllText(globalJsonPath);
+            json = JsonSerializer.Deserialize<GlobalJsonSubset>(text);
+        }
+        catch (IOException e)
+        {
+            logger.Error("Failed to read global.json: " + e.Message);
+            return Error.IoError;
+        }
+
+        if (json.Sdk is not {} sdk)
+        {
+            logger.Error("global.json does not contain an SDK section.");
+            return Error.NoSdkSection;
+        }
+
+        if (sdk.Version is not {} version)
+        {
+            logger.Error("SDK section in global.json does not contain a version.");
+            return Error.NoVersion;
+        }
+
+        var rollForward = sdk.RollForward ?? GlobalJsonSubset.SdkSubset.RollForwardOptions.LatestPatch;
+        var allowPrerelease = sdk.AllowPrerelease ?? true;
+
+        DotnetReleasesIndex versionIndex;
+        try
+        {
+            versionIndex = await DotnetReleasesIndex.FetchLatestIndex(env.DotnetFeedUrls);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            logger.Error("Could not fetch the releases index: ");
+            logger.Error(e.Message);
+            return Error.CouldntFetchReleaseIndex;
+        }
+
+        // Find the best SDK to match the roll-forward policy.
+
+        var installDir = globalJsonPath.GetDirectory() / ".dotnet";
+
+        var sdks = await GetSortedSdks(versionIndex, allowPrerelease);
+
+        ChannelReleaseIndex.Component? Search(Comparison<SemVersion> comparer, bool preferExact)
+        {
+            if (preferExact && BinarySearchLatest(sdks, version, SemVersion.CompareSortOrder) is { } exactMatch)
+            {
+                return exactMatch;
+            }
+            return BinarySearchLatest(sdks, version, comparer);
+        }
+
+        ChannelReleaseIndex.Component? component = rollForward switch
+        {
+            RollForwardOptions.Patch => Search(LatestPatchComparison, preferExact: true),
+            RollForwardOptions.Feature => Search(LatestFeatureComparison, preferExact: true),
+            RollForwardOptions.Minor => Search(LatestMinorComparison, preferExact: true),
+            RollForwardOptions.Major => Search(LatestMajorComparison, preferExact: true),
+            RollForwardOptions.LatestPatch => Search(LatestPatchComparison, preferExact: false),
+            RollForwardOptions.LatestFeature => Search(LatestFeatureComparison, preferExact: false),
+            RollForwardOptions.LatestMinor => Search(LatestMinorComparison, preferExact: false),
+            RollForwardOptions.LatestMajor => Search(LatestMajorComparison, preferExact: false),
+            RollForwardOptions.Disable => Search(SemVersion.CompareSortOrder, preferExact: false),
+        };
+
+        if (component is null)
+        {
+            logger.Error("No SDK found that matches the requested version.");
+            return Error.CantFindRequestedVersion;
+        }
+
+        var downloadUrl = component.Files.Single(f => f.Rid == Utilities.CurrentRID.ToString()).Url;
+
+        var error = await InstallCommand.InstallSdkToDir(downloadUrl, env.CwdFs, installDir, env.TempFs, logger);
+        if (error is not null)
+        {
+            return Error.IoError;
+        }
+
+        return component.Version;
+    }
+
+    /// <summary>
+    /// Compares equal if the major, minor, and feature band versions are equal, and the patch
+    /// version is greater or equal.
+    /// </summary>
+    private static int LatestPatchComparison(SemVersion a, SemVersion b)
+    {
+        if (a.Major != b.Major)
+        {
+            return a.Major.CompareTo(b.Major);
+        }
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor.CompareTo(b.Minor);
+        }
+        // This is where dotnet differs from semver. The semver patch version is the latest
+        // number in the version string, but dotnet expects SDKs versions to end in xnn, where
+        // x is the feature band and nn is the patch level.
+        if ((a.Patch / 100) != (b.Patch / 100))
+        {
+            return (a.Patch / 100).CompareTo(b.Patch / 100);
+        }
+        // If the patch version is >= we will consider the versions 'equal', meaning that they are
+        // compatible.
+        return ((a.Patch % 100) >= (b.Patch % 100)) ? 0 : -1;
+    }
+
+    /// <summary>
+    /// Compares equal if the major and minor versions are equal, and the feature band and patch
+    /// version are greater or equal.
+    /// </summary>
+    private static int LatestFeatureComparison(SemVersion a, SemVersion b)
+    {
+        if (a.Major != b.Major)
+        {
+            return a.Major.CompareTo(b.Major);
+        }
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor.CompareTo(b.Minor);
+        }
+        if (a.Patch != b.Patch)
+        {
+            return a.Patch >= b.Patch ? 0 : -1;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Compares equal if the major versions are equal, and the minor versions are greater or equal.
+    /// </summary>
+    private static int LatestMinorComparison(SemVersion a, SemVersion b)
+    {
+        if (a.Major != b.Major)
+        {
+            return a.Major.CompareTo(b.Major);
+        }
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor >= b.Minor ? 0 : -1;
+        }
+        if (a.Patch != b.Patch)
+        {
+            return a.Patch >= b.Patch ? 0 : -1;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Compares equal if the major versions are greater than or equal.
+    /// </summary>
+    private static int LatestMajorComparison(SemVersion a, SemVersion b)
+    {
+        if (a.Major != b.Major)
+        {
+            return a.Major >= b.Major ? 0 : -1;
+        }
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor >= b.Minor ? 0 : -1;
+        }
+        if (a.Patch != b.Patch)
+        {
+            return a.Patch >= b.Patch ? 0 : -1;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Finds the component with the given version. If multiple components have the same version,
+    /// the one with the newest version is returned.
+    /// </summary>
+    /// <param name="sdks">A list of the components in descending sort order.</param>
+    /// <param name="version">Version of the component to find.</param>
+    /// <param name="comparer">Custom comparison for versions.</param>
+    /// <returns>The component with the newest matching version, or null if no matching version is found.</returns>
+    private static ChannelReleaseIndex.Component? BinarySearchLatest(
+        List<ChannelReleaseIndex.Component> sdks,
+        SemVersion version,
+        Comparison<SemVersion> comparer)
+    {
+        // Note: the list is sorted in descending order.
+        int left = 0;
+        int right = sdks.Count;
+        while (left < right)
+        {
+            int mid = left + (right - left) / 2;
+            if (comparer(sdks[mid].Version, version) > 0)
+            {
+                left = mid + 1;
+            }
+            else
+            {
+                right = mid;
+            }
+        }
+        return left < sdks.Count && comparer(sdks[left].Version, version) == 0 ? sdks[left] : null;
+    }
+
+    /// <summary>
+    /// Returns a sorted (descending) list of SDks. If <paramref name="majorMinorVersion"/> is not
+    /// null, only SDKs for that major+minor version are returned.
+    /// </summary>
+    private static async Task<List<ChannelReleaseIndex.Component>> GetSortedSdks(
+        DotnetReleasesIndex versionIndex,
+        bool allowPrerelease,
+        string? majorMinorVersion = null)
+    {
+        var sdks = new List<ChannelReleaseIndex.Component>();
+        foreach (var releaseIndex in versionIndex.ChannelIndices)
+        {
+            if (majorMinorVersion is not null && majorMinorVersion != releaseIndex.MajorMinorVersion)
+            {
+                continue;
+            }
+            var index = JsonSerializer.Deserialize<ChannelReleaseIndex>(await Program.HttpClient.GetStringAsync(releaseIndex.ChannelReleaseIndexUrl));
+            foreach (var release in index.Releases)
+            {
+                foreach (var sdk in release.Sdks)
+                {
+                    if (allowPrerelease || !sdk.Version.IsPrerelease)
+                    {
+                        sdks.Add(sdk);
+                    }
+                }
+            }
+        }
+        // Sort in descending order.
+        sdks.Sort((a, b) => b.Version.CompareSortOrderTo(a.Version));
+        return sdks;
+    }
+}

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -78,7 +78,7 @@ public sealed class UninstallCommand
 
             logger.Log($"Deleting SDK {verString} from {dir.Name}");
 
-            env.Vfs.DeleteDirectory(sdkDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(sdkDir, isRecursive: true);
         }
     }
 
@@ -93,9 +93,9 @@ public sealed class UninstallCommand
 
             logger.Log($"Deleting Runtime {verString} from {dir.Name}");
 
-            env.Vfs.DeleteDirectory(netcoreappDir, isRecursive: true);
-            env.Vfs.DeleteDirectory(hostfxrDir, isRecursive: true);
-            env.Vfs.DeleteDirectory(packsHostDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(netcoreappDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(hostfxrDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(packsHostDir, isRecursive: true);
         }
     }
 
@@ -109,8 +109,8 @@ public sealed class UninstallCommand
 
             logger.Log($"Deleting ASP.NET pack {verString} from {dir.Name}");
 
-            env.Vfs.DeleteDirectory(aspnetDir, isRecursive: true);
-            env.Vfs.DeleteDirectory(templatesDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(aspnetDir, isRecursive: true);
+            env.HomeFs.DeleteDirectory(templatesDir, isRecursive: true);
         }
     }
 
@@ -121,11 +121,11 @@ public sealed class UninstallCommand
             var verString = version.ToString();
             var winDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.WindowsDesktop.App" / verString;
 
-            if (env.Vfs.DirectoryExists(winDir))
+            if (env.HomeFs.DirectoryExists(winDir))
             {
                 logger.Log($"Deleting Windows Desktop pack {verString} from {dir.Name}");
 
-                env.Vfs.DeleteDirectory(winDir, isRecursive: true);
+                env.HomeFs.DeleteDirectory(winDir, isRecursive: true);
             }
         }
     }

--- a/src/dnvm/Utilities/Result.cs
+++ b/src/dnvm/Utilities/Result.cs
@@ -1,8 +1,10 @@
 
 using System;
+using StaticCs;
 
 namespace Dnvm;
 
+[Closed]
 public abstract record Result<TOk, TErr>
 {
     private Result() { }

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -227,10 +227,13 @@ public static class Utilities
         return null;
     }
 
-    public static async Task<string?> ExtractArchiveToDir(string archivePath, DnvmEnv dnvmFs, UPath dest)
+    public static async Task<string?> ExtractArchiveToDir(
+        string archivePath,
+        IFileSystem tempFs,
+        IFileSystem destFs,
+        UPath dest)
     {
-        dnvmFs.Vfs.CreateDirectory(dest);
-        var tempFs = dnvmFs.TempFs;
+        destFs.CreateDirectory(dest);
         var tempExtractDir = UPath.Root / Path.GetRandomFileName();
         tempFs.CreateDirectory(tempExtractDir);
         using var tempRealPath = new DirectoryResource(tempFs.ConvertPathToInternal(tempExtractDir));
@@ -269,11 +272,11 @@ public static class Utilities
 
                 if (fsItem.IsDirectory)
                 {
-                    dnvmFs.Vfs.CreateDirectory(destPath);
+                    destFs.CreateDirectory(destPath);
                 }
                 else
                 {
-                    ForceReplaceFile(tempFs, fsItem.Path, dnvmFs.Vfs, destPath);
+                    ForceReplaceFile(tempFs, fsItem.Path, destFs, destPath);
                 }
             }
         }

--- a/src/dnvm/dnvm.csproj
+++ b/src/dnvm/dnvm.csproj
@@ -7,8 +7,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
-    <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/VersionCheck.cs
+++ b/test/IntegrationTests/VersionCheck.cs
@@ -12,6 +12,6 @@ public class VersionCheck
     public async Task ReleasesEndpointIsUp()
     {
         var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(DnvmEnv.DefaultDotnetFeedUrls);
-        Assert.NotEmpty(releasesIndex.Releases);
+        Assert.NotEmpty(releasesIndex.ChannelIndices);
     }
 }

--- a/test/Shared/TestOptions.cs
+++ b/test/Shared/TestOptions.cs
@@ -1,4 +1,5 @@
 
+using Zio;
 using Zio.FileSystems;
 
 namespace Dnvm.Test;
@@ -7,16 +8,28 @@ public sealed class TestEnv : IDisposable
 {
     private readonly TempDirectory _userHome = TestUtils.CreateTempDirectory();
     private readonly TempDirectory _dnvmHome = TestUtils.CreateTempDirectory();
+    private readonly TempDirectory _workingDir = TestUtils.CreateTempDirectory();
     private readonly Dictionary<string, string> _envVars = new();
 
     public DnvmEnv DnvmEnv { get; init; }
 
-    public TestEnv(string dotnetFeedUrl, string releasesUrl)
+    public TestEnv(
+        string dotnetFeedUrl,
+        string releasesUrl,
+        UPath? cwdOpt = null)
     {
+        var cwd = cwdOpt ?? UPath.Root;
+
         var physicalFs = DnvmEnv.PhysicalFs;
+        var homeFs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_dnvmHome.Path));
+        var cwdFs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_workingDir.Path));
+        cwdFs.CreateDirectory(cwd);
+
         DnvmEnv = new DnvmEnv(
                 userHome: _userHome.Path,
-                new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_dnvmHome.Path)),
+                homeFs,
+                cwdFs,
+                cwd,
                 isPhysical: true,
                 getUserEnvVar: s => _envVars[s],
                 setUserEnvVar: (name, val) => _envVars[name] = val,

--- a/test/Shared/TestUtils.cs
+++ b/test/Shared/TestUtils.cs
@@ -1,6 +1,7 @@
 
 using System.Runtime.CompilerServices;
 using Semver;
+using Zio;
 
 namespace Dnvm.Test;
 
@@ -32,6 +33,14 @@ public static class TestUtils
         {
             await using var mockServer = new MockServer(taskScope);
             using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl);
+            await test(mockServer, testOptions.DnvmEnv);
+        });
+
+    public static Task RunWithServer(UPath cwd, Func<MockServer, DnvmEnv, Task> test)
+        => TaskScope.With(async taskScope =>
+        {
+            await using var mockServer = new MockServer(taskScope);
+            using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl, cwd);
             await test(mockServer, testOptions.DnvmEnv);
         });
 

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -40,6 +40,15 @@ public sealed class CommandLineTests
     }
 
     [Fact]
+    public void Restore()
+    {
+        var options = CommandLineArguments.ParseRaw(new TestConsole(), [
+            "restore"
+        ]);
+        Assert.True(options!.Command is CommandArguments.RestoreArguments);
+    }
+
+    [Fact]
     public void List()
     {
         var options = CommandLineArguments.ParseRaw(new TestConsole(), [
@@ -391,6 +400,28 @@ Remove a channel from the list of tracked channels.
 
 Arguments:
     <channel>  The channel to untrack.
+
+Options:
+    -h, --help  Show help information.
+
+
+""".NormalizeLineEndings(), console.Output.TrimLines());
+    }
+
+    [Theory]
+    [InlineData("-h")]
+    [InlineData("--help")]
+    public void RestoreHelp(string param)
+    {
+        var console = new TestConsole();
+        Assert.Null(CommandLineArguments.ParseRaw(
+            console,
+            [ "restore", param ]).Command);
+        Assert.Equal("""
+usage: dnvm restore [-h | --help]
+
+Restore the SDK listed in the global.json file in or above the current directory
+to the .dotnet folder in the same directory.
 
 Options:
     -h, --help  Show help information.

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -16,7 +16,7 @@ public sealed class InstallTests
     {
         var sdkInstallDir = DnvmEnv.GetSdkPath(DnvmEnv.DefaultSdkDirName);
         var dotnetFile = sdkInstallDir / Utilities.DotnetExeName;
-        Assert.False(env.Vfs.FileExists(dotnetFile));
+        Assert.False(env.HomeFs.FileExists(dotnetFile));
 
         var logger = new Logger(new TestConsole());
         var options = new CommandArguments.InstallArguments()
@@ -25,8 +25,8 @@ public sealed class InstallTests
         };
         var installResult = await InstallCommand.Run(env, logger, options);
         Assert.Equal(InstallCommand.Result.Success, installResult);
-        Assert.True(env.Vfs.FileExists(dotnetFile));
-        Assert.Contains(Assets.ArchiveToken, env.Vfs.ReadAllText(dotnetFile));
+        Assert.True(env.HomeFs.FileExists(dotnetFile));
+        Assert.Contains(Assets.ArchiveToken, env.HomeFs.ReadAllText(dotnetFile));
 
         var manifest = await env.ReadManifest();
         var expectedManifest = Manifest.Empty.AddSdk(MockServer.DefaultLtsVersion);

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -39,7 +39,7 @@ public sealed class ManifestTests
 }
 """;
         server.ReleasesIndexJson = new() {
-            Releases = [
+            ChannelIndices = [
                 new DotnetReleasesIndex.ChannelIndex {
                     ReleaseType = "lts",
                     SupportPhase = "active",

--- a/test/UnitTests/RestoreTests.cs
+++ b/test/UnitTests/RestoreTests.cs
@@ -1,0 +1,426 @@
+
+using Semver;
+using Spectre.Console.Testing;
+using Xunit;
+using Zio;
+
+namespace Dnvm.Test;
+
+public sealed class RestoreTests
+{
+    [Fact]
+    public async Task NoGlobalJson() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var console = new TestConsole();
+        var logger = new Logger(console);
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(RestoreCommand.Error.NoGlobalJson, restoreResult);
+        Assert.Equal("""
+        Error: No global.json found in the current directory or any of its parents.
+
+        """.NormalizeLineEndings(), console.Output.TrimLines());
+    });
+
+    [Fact]
+    public async Task GlobalJsonNoSdkSection() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {}
+        """);
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(RestoreCommand.Error.NoSdkSection, restoreResult);
+    });
+
+    [Fact]
+    public async Task GlobalJsonNoVersion() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {}
+        }
+        """);
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(RestoreCommand.Error.NoVersion, restoreResult);
+    });
+
+    [Fact]
+    public async Task ExactVersionMatch() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", $$"""
+        {
+            "sdk": {
+                "version": "{{MockServer.DefaultLtsVersion}}"
+            }
+        }
+        """);
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task ExactMatchDirAbove() => await TestUtils.RunWithServer(UPath.Root / "a" / "b" / "c",
+    async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        var jsonPath = UPath.Root / "global.json";
+        env.CwdFs.WriteAllText(jsonPath, $$"""
+        {
+            "sdk": {
+                "version": "{{MockServer.DefaultLtsVersion}}"
+            }
+        }
+        """);
+
+        Assert.False(env.CwdFs.DirectoryExists(UPath.Root / ".dotnet"));
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(UPath.Root / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task NewerPatchVersion() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task LatestPatch() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task LatestFeature() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "latestFeature"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 100), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task LatestMinor() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "latestMinor"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 43, 0), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task LatestMajor() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "latestMajor"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+        server.RegisterReleaseVersion(new(43, 0, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task LatestMajorNoPrerelease() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "latestMajor",
+                "allowPrerelease": false
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+        server.RegisterReleaseVersion(new(43, 0, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(SemVersion.Parse("43.0.0", SemVersionStyles.Strict), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task PatchAndExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "patch"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task FeatureAndExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "feature"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task MinorAndExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "minor"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task MajorAndExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.42",
+                "rollForward": "major"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+        server.RegisterReleaseVersion(new(43, 0, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(SemVersion.Parse("42.42.42", SemVersionStyles.Strict), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task PatchNoExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.40",
+                "rollForward": "patch"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task FeatureNoExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.40",
+                "rollForward": "feature"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 42, 100), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task MinorNoExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.40",
+                "rollForward": "minor"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(new SemVersion(42, 43, 0), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task MajorNoExact() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.40",
+                "rollForward": "major"
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+        server.RegisterReleaseVersion(new(43, 0, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+
+    [Fact]
+    public async Task MajorNoExactNoPrerelease() => await TestUtils.RunWithServer(async (server, env) =>
+    {
+        var logger = new Logger(new TestConsole());
+        env.CwdFs.WriteAllText(env.Cwd / "global.json", """
+        {
+            "sdk": {
+                "version": "42.42.40",
+                "rollForward": "major"
+                "allowPrerelease": false
+            }
+        }
+        """);
+        server.RegisterReleaseVersion(new(42, 42, 100), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 42, 43), "lts", "active");
+        server.RegisterReleaseVersion(new(42, 43, 0), "lts", "active");
+        server.RegisterReleaseVersion(new(43, 0, 0), "lts", "active");
+
+        Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+        var restoreResult = await RestoreCommand.Run(env, logger);
+        Assert.Equal(SemVersion.Parse("43.0.0", SemVersionStyles.Strict), restoreResult);
+        Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+    });
+}

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -26,7 +26,7 @@ public sealed class SelectTests
             Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        var homeFs = env.Vfs;
+        var homeFs = env.HomeFs;
         var defaultSdkDir = DnvmEnv.DefaultSdkDirName;
         var defaultDotnet = DnvmEnv.GetSdkPath(defaultSdkDir) / Utilities.DotnetExeName;
         Assert.True(homeFs.FileExists(defaultDotnet));

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -26,8 +26,8 @@ public sealed class UninstallTests
             SdkDir = "preview"
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[0].LatestSdk, SemVersionStyles.Strict);
-        var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[1].LatestSdk, SemVersionStyles.Strict);
+        var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[0].LatestSdk, SemVersionStyles.Strict);
+        var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[1].LatestSdk, SemVersionStyles.Strict);
         var expectedManifest = Manifest.Empty
             .AddSdk(ltsVersion, new Channel.Latest(), DnvmEnv.DefaultSdkDirName)
             .AddSdk(previewVersion, new Channel.Preview(), new SdkDirName("preview"));
@@ -46,16 +46,16 @@ public sealed class UninstallTests
         };
         Assert.Equal(previewOnly, manifest);
 
-        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.NETCore.App" / ltsVersion.ToString()));
-        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
-        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
-        Assert.False(env.Vfs.DirectoryExists(UPath.Root / "dn" / "host" / "fxr" / ltsVersion.ToString()));
+        Assert.False(env.HomeFs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.NETCore.App" / ltsVersion.ToString()));
+        Assert.False(env.HomeFs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
+        Assert.False(env.HomeFs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
+        Assert.False(env.HomeFs.DirectoryExists(UPath.Root / "dn" / "host" / "fxr" / ltsVersion.ToString()));
 
-        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.NETCore.App" / previewVersion.ToString()));
-        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.AspNetCore.App" / previewVersion.ToString()));
-        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "host" / "fxr" / previewVersion.ToString()));
-        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / previewVersion.ToString()));
-        Assert.True(env.Vfs.DirectoryExists(UPath.Root / "preview" / "templates" / previewVersion.ToString()));
+        Assert.True(env.HomeFs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.NETCore.App" / previewVersion.ToString()));
+        Assert.True(env.HomeFs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.AspNetCore.App" / previewVersion.ToString()));
+        Assert.True(env.HomeFs.DirectoryExists(UPath.Root / "preview" / "host" / "fxr" / previewVersion.ToString()));
+        Assert.True(env.HomeFs.DirectoryExists(UPath.Root / "preview" / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / previewVersion.ToString()));
+        Assert.True(env.HomeFs.DirectoryExists(UPath.Root / "preview" / "templates" / previewVersion.ToString()));
     });
 
     [Fact]
@@ -73,8 +73,8 @@ public sealed class UninstallTests
         });
         Assert.Equal(TrackCommand.Result.Success, result);
 
-        var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[0].LatestSdk, SemVersionStyles.Strict);
-        var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.Releases[1].LatestSdk, SemVersionStyles.Strict);
+        var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[0].LatestSdk, SemVersionStyles.Strict);
+        var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[1].LatestSdk, SemVersionStyles.Strict);
 
         var uninstallConsole = new TestConsole();
         var unResult = await UninstallCommand.Run(env, new Logger(uninstallConsole), new CommandArguments.UninstallArguments

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -137,7 +137,7 @@ public sealed class UpdateTests
         {
             mockServer.ReleasesIndexJson = new()
             {
-                Releases = [ new() {
+                ChannelIndices = [ new() {
                         LatestRelease = version.ToString(),
                         LatestSdk = version.ToString(),
                         MajorMinorVersion = version.ToMajorMinor(),
@@ -198,7 +198,7 @@ public sealed class UpdateTests
             ChannelReleaseIndexUrl = null!
         };
         var releasesIndex = new DotnetReleasesIndex {
-            Releases = [ltsRelease, stsRelease, ltsPreview, stsPreview]
+            ChannelIndices = [ltsRelease, stsRelease, ltsPreview, stsPreview]
         };
 
         var actual = releasesIndex.GetChannelIndex(new Channel.Latest());
@@ -230,7 +230,7 @@ public sealed class UpdateTests
         };
 
         var releasesIndex = new DotnetReleasesIndex {
-            Releases = [previewRelease]
+            ChannelIndices = [previewRelease]
         };
 
         var actual = releasesIndex.GetChannelIndex(new Channel.Preview());
@@ -264,7 +264,7 @@ public sealed class UpdateTests
         result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Lts() });
         Assert.Equal(TrackCommand.Result.Success , result);
 
-        var oldRelease = server.ReleasesIndexJson.Releases.Single(r => r.ReleaseType == "lts");
+        var oldRelease = server.ReleasesIndexJson.ChannelIndices.Single(r => r.ReleaseType == "lts");
         var newSdkVersion = new SemVersion(42, 42, 43);
         var newRelease = server.RegisterReleaseVersion(newSdkVersion, "lts", "active");
         var updateResult = await UpdateCommand.Run(env, _logger, new() { Yes = true });


### PR DESCRIPTION
The restore command downloads a compatible SDK listed in a global.json file in the current working directory or parent thereof. The SDK is expanded into a `.dotnet` directory next to the global.json file. This command does not affect the set of installed SDKs.

Fixes https://github.com/dn-vm/dnvm/issues/165