### PR TITLE
Ensure that updateUserEnvironment respects user input

### DIFF
--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -113,7 +113,7 @@ public class SelfInstallCommand
         {
             Console.WriteLine("One or more paths are missing from the user environment. Attempt to update the user environment?");
             Console.Write("[Y/n]> ");
-            updateUserEnv = Console.ReadLine()?.Trim().ToLowerInvariant() == "y";
+            updateUserEnv = Console.ReadLine()?.Trim().ToLowerInvariant() is not "n";
         }
 
         logger.Log("Proceeding with installation.");

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -113,10 +113,7 @@ public class SelfInstallCommand
         {
             Console.WriteLine("One or more paths are missing from the user environment. Attempt to update the user environment?");
             Console.Write("[Y/n]> ");
-            if (Console.ReadLine()?.Trim().ToLowerInvariant() == "y")
-            {
-                updateUserEnv = true;
-            }
+            updateUserEnv = Console.ReadLine()?.Trim().ToLowerInvariant() == "y";
         }
 
         logger.Log("Proceeding with installation.");


### PR DESCRIPTION
Because `args.UpdateUserEnvironment` is true by default, the self install command would always presume that the user's environment should be updated, regardless of input. Fixes https://github.com/dn-vm/dnvm/issues/171.