### PR TITLE
Fix two bugs in restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --blame-hang-timeout 5min


### PR DESCRIPTION
The bugs are

1. Restore did not narrow down to a single zip/targz suffix
2. Pre-5.0 release entries are not compatible with the new JSON schema. This hasn't really been fixed, just worked-around by only looking at major-minor versions at least as high as the version mentioned in the global.json. The assumption is that people aren't trying to install pre-3.0 SDKs (probably wrong, but left for later).