### PR TITLE
Adopt CancelScope and ScopedHttpClient

### DIFF
--- a/src/dnvm/ManifestSchema/ManifestV5.cs
+++ b/src/dnvm/ManifestSchema/ManifestV5.cs
@@ -66,7 +66,7 @@ public partial record InstalledSdkV5
 
 public static partial class ManifestV5Convert
 {
-    public static async Task<ManifestV5> Convert(this ManifestV4 v4, DotnetReleasesIndex releasesIndex)
+    public static async Task<ManifestV5> Convert(this ManifestV4 v4, ScopedHttpClient httpClient, DotnetReleasesIndex releasesIndex)
     {
         var channelMemo = new SortedDictionary<SemVersion, ChannelReleaseIndex>(SemVersion.SortOrderComparer);
 
@@ -79,7 +79,7 @@ public static partial class ManifestV5Convert
 
             var channelRelease = releasesIndex.ChannelIndices.Single(r => r.MajorMinorVersion == majorMinor.ToMajorMinor());
             channelReleaseIndex = JsonSerializer.Deserialize<ChannelReleaseIndex>(
-                await Program.HttpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
+                await httpClient.GetStringAsync(channelRelease.ChannelReleaseIndexUrl));
             channelMemo[majorMinor] = channelReleaseIndex;
             return channelReleaseIndex;
         };

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -1,23 +1,13 @@
-﻿
-using System;
-using System.IO;
-using System.Net.Http;
-using System.Security.Cryptography;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Semver;
-using Serde;
-using Serde.CmdLine;
 using Spectre.Console;
-using Zio.FileSystems;
-using static System.Environment;
 
 namespace Dnvm;
 
 public static class Program
 {
     public static readonly SemVersion SemVer = SemVersion.Parse(GitVersionInformation.MajorMinorPatch, SemVersionStyles.Strict);
-
-    internal static readonly HttpClient HttpClient = new();
 
     public static async Task<int> Main(string[] args)
     {

--- a/src/dnvm/TrackCommand.cs
+++ b/src/dnvm/TrackCommand.cs
@@ -129,7 +129,7 @@ public sealed class TrackCommand
         DotnetReleasesIndex versionIndex;
         try
         {
-            versionIndex = await DotnetReleasesIndex.FetchLatestIndex(feedUrls);
+            versionIndex = await DotnetReleasesIndex.FetchLatestIndex(dnvmEnv.HttpClient, feedUrls);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
@@ -170,7 +170,7 @@ Proceeding without SDK installation.
         var latestSdkVersion = SemVersion.Parse(latestChannelIndex.LatestSdk, SemVersionStyles.Strict);
         logger.Log("Found latest version: " + latestSdkVersion);
 
-        var result = await InstallCommand.TryGetReleaseFromIndex(versionIndex, channel, latestSdkVersion);
+        var result = await InstallCommand.TryGetReleaseFromIndex(dnvmEnv.HttpClient, versionIndex, channel, latestSdkVersion);
         if (result is not ({} component, {} release))
         {
             throw new InvalidOperationException($"Could not find release {latestSdkVersion} in index. This is a bug.");

--- a/src/dnvm/Utilities/CancelScope.cs
+++ b/src/dnvm/Utilities/CancelScope.cs
@@ -1,0 +1,129 @@
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dnvm;
+
+public sealed partial class CancelScope
+{
+    private readonly CancelScope? _parent;
+    private readonly CancellationTokenSource _cts;
+
+    private CancelScope(CancelScope? parent)
+    {
+        _parent = parent;
+        _cts = parent is null
+            ? new()
+            : CancellationTokenSource.CreateLinkedTokenSource(parent._cts.Token);
+    }
+}
+
+partial class CancelScope
+{
+    private static readonly AsyncLocal<CancelScope> _current = new AsyncLocal<CancelScope>();
+
+    public static CancelScope Current
+    {
+        get
+        {
+            if (_current.Value is null)
+            {
+                _current.Value = new CancelScope(null);
+            }
+            return _current.Value;
+        }
+        private set
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+            _current.Value = value;
+        }
+    }
+
+    public static async Task WithCancelAfter(
+        TimeSpan delay,
+        Func<CancelScope, Task> func,
+        Action<OperationCanceledException>? onCanceled = null)
+    {
+        var parent = Current;
+        Debug.Assert(parent is not null);
+        var scope = new CancelScope(Current);
+        Current = scope;
+        try
+        {
+            scope._cts.CancelAfter(delay);
+            await func(scope);
+        }
+        catch (OperationCanceledException e) when (e.CancellationToken == scope._cts.Token)
+        {
+            onCanceled?.Invoke(e);
+        }
+        finally
+        {
+            scope._cts.Dispose();
+            Debug.Assert(parent is not null);
+            Current = parent;
+        }
+    }
+
+    public static void WithCancelAfter(
+        TimeSpan delay,
+        Action<CancelScope> action,
+        Action<OperationCanceledException>? onCanceled = null)
+    {
+        WithCancelAfter(
+            delay,
+            scope => { action(scope); return Task.CompletedTask; },
+            onCanceled).GetAwaiter().GetResult();
+    }
+
+    public static T WithTimeoutAfter<T>(
+        TimeSpan delay,
+        Func<CancelScope, T> func,
+        Action<OperationCanceledException>? onCanceled = null)
+    {
+        return WithTimeoutAfter(
+            delay,
+            scope => Task.FromResult(func(scope)),
+            onCanceled).GetAwaiter().GetResult();
+    }
+
+    public static async Task<T> WithTimeoutAfter<T>(
+        TimeSpan delay,
+        Func<CancelScope, Task<T>> func,
+        Action<OperationCanceledException>? onCanceled = null)
+    {
+        var parent = Current;
+        Debug.Assert(parent is not null);
+        var scope = new CancelScope(Current);
+        Current = scope;
+        try
+        {
+            scope._cts.CancelAfter(delay);
+            return await func(scope);
+        }
+        catch (OperationCanceledException e) when (e.CancellationToken == scope._cts.Token)
+        {
+            onCanceled?.Invoke(e);
+            throw new TimeoutException("Operation timed out", e);
+        }
+        finally
+        {
+            scope._cts.Dispose();
+            Debug.Assert(parent is not null);
+            Current = parent;
+        }
+    }
+
+    public CancellationToken Token => _cts.Token;
+
+    public void Cancel()
+    {
+        _cts.Cancel();
+        _cts.Token.ThrowIfCancellationRequested();
+    }
+}

--- a/src/dnvm/Utilities/Extensions.cs
+++ b/src/dnvm/Utilities/Extensions.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Dnvm;

--- a/src/dnvm/Utilities/ScopedHttpClient.cs
+++ b/src/dnvm/Utilities/ScopedHttpClient.cs
@@ -1,0 +1,76 @@
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dnvm;
+
+public sealed class ScopedHttpClient(HttpClient client)
+{
+    internal async Task<ScopedHttpResponseMessage> GetAsync([StringSyntax("Uri")] string url)
+    {
+        return new ScopedHttpResponseMessage(
+            await client.GetAsync(url, CancelScope.Current.Token)
+        );
+    }
+
+    internal async Task<ScopedHttpResponseMessage> GetAsync(
+        [StringSyntax("Uri")] string url,
+        HttpCompletionOption completionOption)
+    {
+        return new ScopedHttpResponseMessage(
+            await client.GetAsync(url, completionOption, CancelScope.Current.Token)
+        );
+    }
+
+    internal Task<string> GetStringAsync(string url)
+    {
+        // This is a commonly used method for small requests, so we set a default timeout in case
+        // the caller forgets to set one
+        return CancelScope.WithTimeoutAfter(
+            DnvmEnv.DefaultTimeout,
+            _ => client.GetStringAsync(url, CancelScope.Current.Token)
+        );
+    }
+
+    internal Task<Stream> GetStreamAsync(string uri)
+        => client.GetStreamAsync(uri, CancelScope.Current.Token);
+}
+
+public sealed class ScopedHttpResponseMessage(HttpResponseMessage response) : IDisposable
+{
+    public bool IsSuccessStatusCode => response.IsSuccessStatusCode;
+
+    public ScopedHttpContent Content => new(response.Content);
+
+    public void Dispose() => response.Dispose();
+
+    public void EnsureSuccessStatusCode() => response.EnsureSuccessStatusCode();
+}
+
+public sealed class ScopedHttpContent(HttpContent content)
+{
+    public HttpContentHeaders Headers => content.Headers;
+
+    public Task<string> ReadAsStringAsync()
+    {
+        return content.ReadAsStringAsync(CancelScope.Current.Token);
+    }
+
+    public async Task<ScopedStream> ReadAsStreamAsync()
+    {
+        return new(await content.ReadAsStreamAsync(CancelScope.Current.Token));
+    }
+}
+
+public sealed class ScopedStream(Stream stream) : IDisposable
+{
+    public void Dispose() => stream.Dispose();
+
+    public ValueTask<int> ReadAsync(Memory<byte> buffer)
+        => stream.ReadAsync(buffer, CancelScope.Current.Token);
+}

--- a/test/IntegrationTests/UpdateTests.cs
+++ b/test/IntegrationTests/UpdateTests.cs
@@ -55,7 +55,7 @@ public sealed class UpdateTests
         };
         var result = await ProcUtil.RunWithOutput(
             dnvmTmpPath,
-            $"update --self -v --feed-url {mockServer.DnvmReleasesUrl}",
+            $"update --self -v --dnvm-url {mockServer.DnvmReleasesUrl}",
             new() { ["DNVM_HOME"] = dnvmHome.Path });
         var output = result.Out;
         var error = result.Error;

--- a/test/IntegrationTests/VersionCheck.cs
+++ b/test/IntegrationTests/VersionCheck.cs
@@ -11,7 +11,8 @@ public class VersionCheck
     [Fact]
     public async Task ReleasesEndpointIsUp()
     {
-        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(DnvmEnv.DefaultDotnetFeedUrls);
+        var env = DnvmEnv.CreateDefault();
+        var releasesIndex = await DotnetReleasesIndex.FetchLatestIndex(env.HttpClient, DnvmEnv.DefaultDotnetFeedUrls);
         Assert.NotEmpty(releasesIndex.ChannelIndices);
     }
 }

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -63,8 +63,7 @@ public sealed class UpdateTests
             releasesIndex,
             manifest,
             yes: false,
-            env.DnvmReleasesUrl!,
-            cancellationToken);
+            env.DnvmReleasesUrl!);
         Assert.Contains("dnvm is out of date", console.Output);
     });
 


### PR DESCRIPTION
This moves the repo to using a CancelScope instead of passing around CancellationTokens. This is a design pattern from structured concurrency. It also introduces a ScopedHttpClient which respects CancelScope. The ScopedHttpClient is also attached to a DnvmEnv, instead of being a global static, which allows for testing and more configuration options.

Lastly, the ScopedHttpClient now no longer has a 100 second global timeout. Instead, timeouts are regulated per-scope or through the specialty GetStringAsync method (which has a default timeout).