### PR TITLE
Allow enabling preview versions

### DIFF
--- a/src/dnvm/DnvmReleases.cs
+++ b/src/dnvm/DnvmReleases.cs
@@ -8,6 +8,8 @@ namespace Dnvm;
 [GenerateSerde]
 public partial record DnvmReleases(Release LatestVersion)
 {
+    public Release? LatestPreview { get; init; }
+
     [GenerateSerde]
     public partial record Release(
         string Version,

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -1,17 +1,13 @@
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Semver;
 using Serde;
 using Serde.Json;
-using StaticCs;
 using StaticCs.Collections;
 
 namespace Dnvm;
@@ -111,8 +107,9 @@ public static partial class ManifestUtils
         var version = JsonSerializer.Deserialize<ManifestVersionOnly>(manifestSrc).Version;
         // Handle versions that don't need the release index to convert
         Manifest? manifest = version switch {
-            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert(),
-            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert(),
+            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert().Convert(),
+            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert().Convert(),
+            ManifestV7.VersionField => JsonSerializer.Deserialize<ManifestV7>(manifestSrc).Convert(),
             Manifest.VersionField => JsonSerializer.Deserialize<Manifest>(manifestSrc),
             _ => null
         };
@@ -126,10 +123,14 @@ public static partial class ManifestUtils
         return version switch
         {
             // The first version didn't have a version field
-            null => (await JsonSerializer.Deserialize<ManifestV1>(manifestSrc).Convert().Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert(),
-            ManifestV2.VersionField => (await JsonSerializer.Deserialize<ManifestV2>(manifestSrc).Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert(),
-            ManifestV3.VersionField => (await JsonSerializer.Deserialize<ManifestV3>(manifestSrc).Convert().Convert(httpClient, releasesIndex)).Convert().Convert(),
-            ManifestV4.VersionField => (await JsonSerializer.Deserialize<ManifestV4>(manifestSrc).Convert(httpClient, releasesIndex)).Convert().Convert(),
+            null => (await JsonSerializer.Deserialize<ManifestV1>(manifestSrc)
+                .Convert().Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+            ManifestV2.VersionField => (await JsonSerializer.Deserialize<ManifestV2>(manifestSrc)
+                .Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+            ManifestV3.VersionField => (await JsonSerializer.Deserialize<ManifestV3>(manifestSrc)
+                .Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+            ManifestV4.VersionField => (await JsonSerializer.Deserialize<ManifestV4>(manifestSrc)
+                .Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
             _ => throw new InvalidDataException("Unknown manifest version: " + version)
         };
     }

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -22,19 +22,36 @@ public static class Program
             // Error was already printed, exit with failure.
             return 1;
         }
-        if (options.Command is null)
-        {
-            // Help was requested, exit with success.
-            return 0;
-        }
 
         // Self-install is special, since we don't know the DNVM_HOME yet.
         if (options.Command is CommandArguments.SelfInstallArguments selfInstallArgs)
         {
             return (int)await SelfInstallCommand.Run(logger, selfInstallArgs);
         }
+
         using var env = DnvmEnv.CreateDefault();
+        if (options.Command is null)
+        {
+            if (options.EnableDnvmPreviews)
+            {
+                return await EnableDnvmPreviews(env);
+            }
+            else
+            {
+                // Help was requested, exit with success.
+                return 0;
+            }
+        }
+
         return await Dnvm(env, logger, options);
+    }
+
+    public static async Task<int> EnableDnvmPreviews(DnvmEnv env)
+    {
+        var manifest = await ManifestUtils.ReadOrCreateManifest(env);
+        manifest = manifest with { PreviewsEnabled = true };
+        env.WriteManifest(manifest);
+        return 0;
     }
 
     internal static async Task<int> Dnvm(DnvmEnv env, Logger logger, CommandLineArguments options)

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -46,11 +46,11 @@ public class SelfInstallCommand
         }
 
         DnvmEnv? env = null;
-        if (args.Update)
+        if (args.Update is true)
         {
             logger.Log("Running self-update install");
             env = DnvmEnv.CreateDefault();
-            return await SelfUpdate(logger, env);
+            return await SelfUpdate(args.DestPath, logger, env);
         }
 
         logger.Log("Starting dnvm install");
@@ -182,9 +182,8 @@ public class SelfInstallCommand
     /// <summary>
     /// Install the running binary to the specified location.
     /// </summary>
-    internal static async Task<Result> SelfUpdate(Logger logger, DnvmEnv dnvmEnv)
+    internal static async Task<Result> SelfUpdate(string? destPath, Logger logger, DnvmEnv dnvmEnv)
     {
-        logger.Log("SDK install directory: ");
         SdkDirName sdkDirName;
         try
         {
@@ -198,7 +197,11 @@ public class SelfInstallCommand
 
         var dnvmHome = dnvmEnv.HomeFs.ConvertPathToInternal(UPath.Root);
         var SdkInstallPath = Path.Combine(dnvmHome, sdkDirName.Name);
-        if (!ReplaceBinary(dnvmHome, logger))
+        if (destPath is null)
+        {
+            destPath = dnvmEnv.RealPath(DnvmEnv.DnvmExePath);
+        }
+        if (!ReplaceBinary(dnvmHome, destPath, logger))
         {
             return Result.SelfInstallFailed;
         }
@@ -216,9 +219,8 @@ public class SelfInstallCommand
 
         return Result.Success;
 
-        static bool ReplaceBinary(string dnvmHome, Logger logger)
+        static bool ReplaceBinary(string dnvmHome, string destPath, Logger logger)
         {
-            var destPath = Path.Combine(dnvmHome, Utilities.DnvmExeName);
             var srcPath = Utilities.ProcessPath;
             try
             {

--- a/src/dnvm/Utilities/ProcUtil.cs
+++ b/src/dnvm/Utilities/ProcUtil.cs
@@ -38,7 +38,9 @@ public static class ProcUtil
             await error.ConfigureAwait(false));
     }
 
-    public static async Task<ProcResult> RunShell(string scriptContent)
+    public static async Task<ProcResult> RunShell(
+        string scriptContent,
+        Dictionary<string, string>? envVars = null)
     {
         var psi = new ProcessStartInfo
         {
@@ -47,6 +49,13 @@ public static class ProcUtil
             RedirectStandardError = true,
             RedirectStandardInput = true
         };
+        if (envVars is not null)
+        {
+            foreach (var (k, v) in envVars)
+            {
+                psi.Environment[k] = v;
+            }
+        }
         var proc = Process.Start(psi)!;
         await proc.StandardInput.WriteAsync(scriptContent);
         proc.StandardInput.Close();

--- a/test/IntegrationTests/UpdateTests.cs
+++ b/test/IntegrationTests/UpdateTests.cs
@@ -42,6 +42,53 @@ public sealed class UpdateTests
     });
 
     [Fact]
+    public async Task EnablePreviewsAndDownload() => await TestWithServer(async mockServer =>
+    {
+        using var tmpDir = TestUtils.CreateTempDirectory();
+        using var dnvmHome = TestUtils.CreateTempDirectory();
+        var dnvmTmpPath = tmpDir.CopyFile(SelfInstallTests.DnvmExe);
+
+        var startVer = Program.SemVer;
+        mockServer.DnvmReleases = mockServer.DnvmReleases with {
+            LatestVersion = mockServer.DnvmReleases.LatestVersion with {
+                Version = startVer.ToString() // Keep the same version
+            },
+            LatestPreview = mockServer.DnvmReleases.LatestVersion with {
+                Version = startVer.WithMajor(startVer.Major + 1).WithPrerelease("preview").ToString()
+            }
+        };
+
+        // There is a newer version in the preview, but previews are not enabled yet, so
+        // the update should say that the version is up-to-date.
+        var proc = await ProcUtil.RunWithOutput(dnvmTmpPath,
+            $"update --self -v --dnvm-url {mockServer.DnvmReleasesUrl}",
+            new() { ["DNVM_HOME"] = dnvmHome.Path });
+        var output = proc.Out;
+        var error = proc.Error;
+        Assert.Equal("", error);
+        Assert.Contains("dnvm is up-to-date", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, proc.ExitCode);
+
+        proc = await ProcUtil.RunWithOutput(dnvmTmpPath,
+            "--enable-dnvm-previews",
+            new() { ["DNVM_HOME"] = dnvmHome.Path });
+        Assert.Equal(0, proc.ExitCode);
+
+        // This will download the new version and run the installer, which should
+        // replace the old version. However, the endpoint is set to serve a shell
+        // script instead. The shell script will print a message to stdout, which
+        // we can check for.
+        proc = await ProcUtil.RunWithOutput(dnvmTmpPath,
+            $"update --self -v --dnvm-url {mockServer.DnvmReleasesUrl}",
+            new() { ["DNVM_HOME"] = dnvmHome.Path });
+        output = proc.Out;
+        error = proc.Error;
+        Assert.Equal("", error);
+        Assert.Contains("Hello from dnvm test", output);
+        Assert.Equal(0, proc.ExitCode);
+    });
+
+    [Fact]
     public Task SelfUpdateUpToDate() => TestWithServer(async mockServer =>
     {
         using var tmpDir = TestUtils.CreateTempDirectory();

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -63,7 +63,16 @@ public sealed class MockServer : IAsyncDisposable
                 ["linux-x64"] = $"{PrefixString}dnvm/dnvm.tar.gz",
                 ["osx-x64"] = $"{PrefixString}dnvm/dnvm.tar.gz",
                 ["win-x64"] = $"{PrefixString}dnvm/dnvm.zip"
-        }));
+        }))
+        {
+            LatestPreview = new(
+                Version: "99.99.99-preview",
+                Artifacts: new() {
+                    ["linux-x64"] = $"{PrefixString}dnvm/dnvm.tar.gz",
+                    ["osx-x64"] = $"{PrefixString}dnvm/dnvm.tar.gz",
+                    ["win-x64"] = $"{PrefixString}dnvm/dnvm.zip"
+            })
+        };
     }
 
     [MemberNotNull(nameof(ReleasesIndexJson))]

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -9,11 +9,12 @@ namespace Dnvm.Test;
 public sealed class CommandLineTests
 {
     private static readonly string ExpectedHelpText = """
-        usage: dnvm [-h | --help] <command>
+        usage: dnvm [--enable-dnvm-previews] [-h | --help] <command>
 
         Install and manage .NET SDKs.
 
         Options:
+            --enable-dnvm-previews  Enable dnvm previews.
             -h, --help  Show help information.
 
         Commands:
@@ -158,6 +159,15 @@ Channel must be one of:
         });
     }
 
+    [Fact]
+    public void EnableDnvmPreviews()
+    {
+        var options = CommandLineArguments.ParseRaw(new TestConsole(), [
+            "--enable-dnvm-previews",
+        ]);
+        Assert.True(options!.EnableDnvmPreviews);
+    }
+
     [Theory]
     [InlineData("-h")]
     [InlineData("--help")]
@@ -292,7 +302,7 @@ given name.
             [ "selfinstall", param ]).Command);
         Assert.Equal("""
 usage: dnvm selfinstall [-v | --verbose] [-f | --force] [--feed-url <feedUrl>]
-[-y] [--update] [-h | --help]
+[-y] [--update] [--dest-path <destPath>] [-h | --help]
 
 Install dnvm to the local machine.
 
@@ -301,8 +311,9 @@ Options:
     -f, --force  Force install the given SDK, even if already installed
     --feed-url  <feedUrl>  Set the feed URL to download the SDK from.
     -y  Answer yes to all prompts.
-    --update  [internal] Update the dnvm installation in the current location.
-Only intended to be called from dnvm.
+    --update  [internal] Update the current dnvm installation. Only intended to
+be called from dnvm.
+    --dest-path  <destPath>  Set the destination path for the dnvm executable.
     -h, --help  Show help information.
 
 

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Runtime.InteropServices.Marshalling;
 using System.Security.Cryptography;
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Semver;
 using Serde.Json;
 using Spectre.Console.Testing;
@@ -23,16 +24,16 @@ public sealed class UpdateTests
         _logger = new Logger(new TestConsole());
     }
 
-    private static Task TestWithServer(Func<MockServer, DnvmEnv, CancellationToken, Task> test)
+    private static Task TestWithServer(Func<MockServer, DnvmEnv, Task> test)
         => TaskScope.With(async taskScope =>
         {
             await using var mockServer = new MockServer(taskScope);
             using var testOptions = new TestEnv(mockServer.PrefixString, mockServer.DnvmReleasesUrl);
-            await test(mockServer, testOptions.DnvmEnv, taskScope.CancellationToken);
+            await test(mockServer, testOptions.DnvmEnv);
         });
 
     [Fact]
-    public Task UpdateChecksForSelfUpdate() => TestWithServer(async (mockServer, env, cancellationToken) =>
+    public Task UpdateChecksForSelfUpdate() => TestWithServer(async (mockServer, env) =>
     {
         var sdkDir = DnvmEnv.DefaultSdkDirName;
         var manifest = new Manifest
@@ -99,7 +100,7 @@ public sealed class UpdateTests
     });
 
     [Fact]
-    public async Task InstallAndUpdate() => await TestWithServer(async (mockServer, env, cancellationToken) =>
+    public async Task InstallAndUpdate() => await TestWithServer(async (mockServer, env) =>
     {
         var baseVersion = new SemVersion(41, 0, 0);
         var upgradeVersion = new SemVersion(41, 0, 1);


### PR DESCRIPTION
Adds a new section for preview versions to the dnvm releases json file. This will allow for two release trains: stable and preview.