### PR TITLE
Downgrade gitversion to 5.11.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "gitversion.tool": {
-      "version": "5.12.0",
+      "version": "5.11.0",
       "commands": [
         "dotnet-gitversion"
       ]


### PR DESCRIPTION
Works around versioning problems with prerelease tags.