### PR TITLE
Fix restore command absolute path error for Windows

### DIFF
--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -115,11 +115,12 @@ public sealed partial class DnvmEnv : IDisposable
         Action<string, string> setUserEnvVar)
     {
         Directory.CreateDirectory(realPath);
+
         return new DnvmEnv(
             userHome: GetFolderPath(SpecialFolder.UserProfile, SpecialFolderOption.DoNotVerify),
             new SubFileSystem(PhysicalFs, PhysicalFs.ConvertPathFromInternal(realPath)),
             PhysicalFs,
-            new UPath(Environment.CurrentDirectory),
+            PhysicalFs.ConvertPathFromInternal(Environment.CurrentDirectory),
             isPhysical: true,
             getUserEnvVar,
             setUserEnvVar);

--- a/test/IntegrationTests/SelfInstallTests.cs
+++ b/test/IntegrationTests/SelfInstallTests.cs
@@ -3,6 +3,7 @@ using Spectre.Console;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Xunit;
 using Xunit.Abstractions;
@@ -330,7 +331,11 @@ echo "DOTNET_ROOT: $DOTNET_ROOT"
         Directory.CreateDirectory(sdkDir);
         var fakeDotnet = Path.Combine(sdkDir, Utilities.DotnetExeName);
         Assets.MakeEchoExe(fakeDotnet, "Hello from dotnet test");
-        _ = await ProcUtil.RunWithOutput("chmod", $"+x {fakeDotnet}");
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            _ = await ProcUtil.RunWithOutput("chmod", $"+x {fakeDotnet}");
+        }
 
         var startVer = Program.SemVer;
         var result = await ProcUtil.RunWithOutput(

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -1,11 +1,9 @@
 
-using System.Net.Security;
-using Serde.Json;
 using Dnvm;
-using Dnvm.Test;
 using Semver;
 using Xunit;
-using System.Net.NetworkInformation;
+
+namespace Dnvm.Test;
 
 public sealed class ManifestTests
 {

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -1,12 +1,9 @@
 
-using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
-using Dnvm.Test;
 using Spectre.Console.Testing;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Dnvm;
+namespace Dnvm.Test;
 
 public sealed class SelectTests
 {


### PR DESCRIPTION
When I run `dnvm restore` on Windows I get the following error:

```
Unhandled exception. System.ArgumentException: Path `C:/Projects/dnvm/global.json` must be absolute (Parameter 'path')
   at Zio.UPathExtensions.AssertAbsolute(UPath, String) + 0x1a7
   at Zio.FileSystems.FileSystem.ValidatePath(UPath, String, Boolean) + 0x66
   at Zio.FileSystems.FileSystem.FileExists(UPath) + 0x2e
   at Dnvm.RestoreCommand.<Run>d__1.MoveNext() + 0xa9
--- End of stack trace from previous location ---
   at Dnvm.Program.<Dnvm>d__3.MoveNext() + 0x4a7
--- End of stack trace from previous location ---
   at Dnvm.Program.<Main>d__1.MoveNext() + 0x259
--- End of stack trace from previous location ---
   at Dnvm.Program.<Main>(String[] args) + 0x28
```

This is because on Windows, `UPath(Environment.CurrentDirectory)` returns a non-absolute Windows-style (i.e. C:/) path. Calling ConvertPathFromInternal should address these issues.

While getting tests up and running, I updated ManifestTests and SelectTests to use the same Dnvm.Tests namespace as the other tests. I also made the chmod call conditional on platform in RunUpdateSelfInstaller so it works cross-platform.