### PR TITLE
Add --local flag to restore

### DIFF
--- a/src/dnvm/CommandLineArguments.cs
+++ b/src/dnvm/CommandLineArguments.cs
@@ -174,9 +174,17 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("restore", Summary = "Restore the SDK listed in the global.json file.",
-        Description = "Downloads the SDK in the global.json in or above the current directory to the .dotnet folder in the same directory.")]
+        Description = "Downloads the SDK in the global.json in or above the current directory.")]
     public sealed partial record RestoreArgs : DnvmSubCommand
     {
+        [CommandOption("-l|--local", Description = "Install the sdk into the .dotnet folder in the same directory as global.json.")]
+        public bool? Local { get; init; } = null;
+
+        [CommandOption("-f|--force", Description = "Force install the SDK, even if already installed.")]
+        public bool? Force { get; init; } = null;
+
+        [CommandOption("-v|--verbose", Description = "Print extra debugging info to the console.")]
+        public bool? Verbose { get; init; } = null;
     }
 
     /// <summary>

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -68,7 +68,7 @@ public static partial class InstallCommand
         var sdkVersion = options.SdkVersion;
         var channel = new Channel.VersionedMajorMinor(sdkVersion.Major, sdkVersion.Minor);
 
-        if (!options.Force && manifest.InstalledSdks.Any(s => s.SdkVersion == sdkVersion && s.SdkDirName == sdkDir))
+        if (!options.Force && ManifestUtils.IsSdkInstalled(manifest, sdkVersion, sdkDir))
         {
             logger.Log($"Version {sdkVersion} is already installed in directory '{sdkDir.Name}'." +
                 " Skipping installation. To install anyway, pass --force.");
@@ -241,7 +241,7 @@ public static partial class InstallCommand
         var result = JsonSerializer.Serialize(manifest);
         logger.Info("Existing manifest: " + result);
 
-        if (!manifest.InstalledSdks.Any(s => s.SdkVersion == sdkVersion && s.SdkDirName == sdkDir))
+        if (!ManifestUtils.IsSdkInstalled(manifest, sdkVersion, sdkDir))
         {
             manifest = manifest with
             {

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -115,6 +115,11 @@ public static partial class ManifestUtils
         };
     }
 
+    public static bool IsSdkInstalled(Manifest manifest, SemVersion version, SdkDirName dirName)
+    {
+        return manifest.InstalledSdks.Any(s => s.SdkVersion == version && s.SdkDirName == dirName);
+    }
+
     /// <summary>
     /// Either reads a manifest in the current format, or reads a
     /// manifest in the old format and converts it to the new format.

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -74,7 +74,7 @@ public static class Program
             DnvmSubCommand.UntrackArgs a => await UntrackCommand.Run(env, logger, a.Channel),
             DnvmSubCommand.UninstallArgs a => await UninstallCommand.Run(env, logger, a.SdkVersion, a.SdkDir),
             DnvmSubCommand.PruneArgs a => await PruneCommand.Run(env, logger, a),
-            DnvmSubCommand.RestoreArgs => await RestoreCommand.Run(env, logger) switch {
+            DnvmSubCommand.RestoreArgs a => await RestoreCommand.Run(env, logger, a) switch {
                 Result<SemVersion, RestoreCommand.Error>.Ok => 0,
                 Result<SemVersion, RestoreCommand.Error>.Err x => (int)x.Value,
             },

--- a/src/dnvm/RestoreCommand.cs
+++ b/src/dnvm/RestoreCommand.cs
@@ -245,6 +245,7 @@ public static partial class RestoreCommand
             return Error.CantFindRequestedVersion;
         }
 
+        logger.Log($"Found version {sdk.Version} in global.json. Selected version {release.Sdk.Version} based on roll forward rules.");
         var downloadUrl = release.Sdk.Files.Single(f => f.Rid == Utilities.CurrentRID.ToString() && f.Url.EndsWith(Utilities.ZipSuffix)).Url;
 
         if (options.Local)

--- a/src/dnvm/RestoreCommand.cs
+++ b/src/dnvm/RestoreCommand.cs
@@ -8,10 +8,12 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Semver;
 using Serde;
+using Serde.CmdLine;
 using Serde.Json;
 using Spectre.Console;
 using StaticCs;
 using Zio;
+using static Dnvm.InstallCommand;
 using RollForwardOptions =  Dnvm.GlobalJsonSubset.SdkSubset.RollForwardOptions;
 
 namespace Dnvm;
@@ -128,7 +130,26 @@ public static partial class RestoreCommand
         CantFindRequestedVersion = 6,
     }
 
-    public static async Task<Result<SemVersion, Error>> Run(DnvmEnv env, Logger logger)
+    public sealed record Options
+    {
+        public bool Local { get; init; }
+
+        public bool Force { get; init; }
+
+        public bool Verbose { get; init; }
+    }
+
+    public static Task<Result<SemVersion, Error>> Run(DnvmEnv env, Logger logger, DnvmSubCommand.RestoreArgs args)
+    {
+        return Run(env, logger, new Options
+        {
+            Local = args.Local ?? false,
+            Force = args.Force ?? false,
+            Verbose = args.Verbose ?? false,
+        });
+    }
+
+    public static async Task<Result<SemVersion, Error>> Run(DnvmEnv env, Logger logger, Options options)
     {
         UPath? globalJsonPathOpt = null;
         UPath cwd = env.Cwd;
@@ -196,18 +217,18 @@ public static partial class RestoreCommand
 
         var installDir = globalJsonPath.GetDirectory() / ".dotnet";
 
-        var sdks = await GetSortedSdks(env.HttpClient, versionIndex, allowPrerelease, sdk.Version.ToMajorMinor());
+        var releases = await GetSortedReleases(env.HttpClient, versionIndex, allowPrerelease, sdk.Version.ToMajorMinor());
 
-        ChannelReleaseIndex.Component? Search(Comparison<SemVersion> comparer, bool preferExact)
+        ChannelReleaseIndex.Release? Search(Comparison<SemVersion> comparer, bool preferExact)
         {
-            if (preferExact && BinarySearchLatest(sdks, version, SemVersion.CompareSortOrder) is { } exactMatch)
+            if (preferExact && BinarySearchLatest(releases, version, SemVersion.CompareSortOrder) is { } exactMatch)
             {
                 return exactMatch;
             }
-            return BinarySearchLatest(sdks, version, comparer);
+            return BinarySearchLatest(releases, version, comparer);
         }
 
-        ChannelReleaseIndex.Component? component = rollForward switch
+        ChannelReleaseIndex.Release? release = rollForward switch
         {
             RollForwardOptions.Patch => Search(LatestPatchComparison, preferExact: true),
             RollForwardOptions.Feature => Search(LatestFeatureComparison, preferExact: true),
@@ -220,30 +241,59 @@ public static partial class RestoreCommand
             RollForwardOptions.Disable => Search(SemVersion.CompareSortOrder, preferExact: false),
         };
 
-        if (component is null)
+        if (release is null)
         {
             logger.Error("No SDK found that matches the requested version.");
             return Error.CantFindRequestedVersion;
         }
 
-        var downloadUrl = component.Files.Single(f => f.Rid == Utilities.CurrentRID.ToString() && f.Url.EndsWith(Utilities.ZipSuffix)).Url;
+        var downloadUrl = release.Sdk.Files.Single(f => f.Rid == Utilities.CurrentRID.ToString() && f.Url.EndsWith(Utilities.ZipSuffix)).Url;
 
-        var error = await InstallCommand.InstallSdkToDir(
-            curMuxerVersion: null, // we shouldn't have a muxer yet, and we can overwrite it if we do
-            component.Version,
-            env.HttpClient,
-            downloadUrl,
-            env.CwdFs,
-            installDir,
-            env.TempFs,
-            logger
-        );
-        if (error is not null)
+        if (options.Local)
         {
-            return Error.IoError;
+            var error = await InstallCommand.InstallSdkToDir(
+                curMuxerVersion: null, // we shouldn't have a muxer yet, and we can overwrite it if we do
+                release.Sdk.Version,
+                env.HttpClient,
+                downloadUrl,
+                env.CwdFs,
+                installDir,
+                env.TempFs,
+                logger
+            );
+            if (error is not null)
+            {
+                return Error.IoError;
+            }
+        }
+        else
+        {
+            // TODO: Refactor this duplication
+            Manifest manifest;
+            try
+            {
+                manifest = await ManifestUtils.ReadOrCreateManifest(env);
+            }
+            catch (InvalidDataException)
+            {
+                logger.Error("Manifest file corrupted");
+                return Error.IoError; //Result.ManifestFileCorrupted;
+            }
+            catch (Exception e) when (e is not OperationCanceledException)
+            {
+                logger.Error("Error reading manifest file: " + e.Message);
+                return Error.IoError; // Result.ManifestIOError;
+            }
+
+
+            var error = await InstallCommand.InstallSdk(env, manifest, release.Sdk, release, manifest.CurrentSdkDir, logger);
+            if (error is not Result<Manifest, InstallError>.Ok)
+            {
+                return Error.IoError;
+            }
         }
 
-        return component.Version;
+        return release.Sdk.Version;
     }
 
     /// <summary>
@@ -334,25 +384,25 @@ public static partial class RestoreCommand
     }
 
     /// <summary>
-    /// Finds the component with the given version. If multiple components have the same version,
-    /// the one with the newest version is returned.
+    /// Finds the release with the given SDK version. If multiple releases have the same SDK version,
+    /// the one with the newest SDK version is returned.
     /// </summary>
-    /// <param name="sdks">A list of the components in descending sort order.</param>
-    /// <param name="version">Version of the component to find.</param>
+    /// <param name="releases">A list of the releases in descending sort order.</param>
+    /// <param name="version">Version of the SDK to find.</param>
     /// <param name="comparer">Custom comparison for versions.</param>
-    /// <returns>The component with the newest matching version, or null if no matching version is found.</returns>
-    private static ChannelReleaseIndex.Component? BinarySearchLatest(
-        List<ChannelReleaseIndex.Component> sdks,
+    /// <returns>The SDK with the newest matching version, or null if no matching version is found.</returns>
+    private static ChannelReleaseIndex.Release? BinarySearchLatest(
+        List<ChannelReleaseIndex.Release> releases,
         SemVersion version,
         Comparison<SemVersion> comparer)
     {
         // Note: the list is sorted in descending order.
         int left = 0;
-        int right = sdks.Count;
+        int right = releases.Count;
         while (left < right)
         {
             int mid = left + (right - left) / 2;
-            if (comparer(sdks[mid].Version, version) > 0)
+            if (comparer(releases[mid].Sdk.Version, version) > 0)
             {
                 left = mid + 1;
             }
@@ -361,20 +411,20 @@ public static partial class RestoreCommand
                 right = mid;
             }
         }
-        return left < sdks.Count && comparer(sdks[left].Version, version) == 0 ? sdks[left] : null;
+        return left < releases.Count && comparer(releases[left].Sdk.Version, version) == 0 ? releases[left] : null;
     }
 
     /// <summary>
-    /// Returns a sorted (descending) list of SDks. If <paramref name="minMajorMinor"/> is not
-    /// null, only SDKs for that major+minor version are returned.
+    /// Returns list of releases sorted (descending) by SDK version. If <paramref name="minMajorMinor"/> is not
+    /// null, only releases for that major+minor version are returned.
     /// </summary>
-    private static async Task<List<ChannelReleaseIndex.Component>> GetSortedSdks(
+    private static async Task<List<ChannelReleaseIndex.Release>> GetSortedReleases(
         ScopedHttpClient httpClient,
         DotnetReleasesIndex versionIndex,
         bool allowPrerelease,
         string minMajorMinor)
     {
-        var sdks = new List<ChannelReleaseIndex.Component>();
+        var releases = new List<ChannelReleaseIndex.Release>();
         foreach (var releaseIndex in versionIndex.ChannelIndices)
         {
             if (minMajorMinor is not null && double.Parse(minMajorMinor) > double.Parse(releaseIndex.MajorMinorVersion))
@@ -388,13 +438,13 @@ public static partial class RestoreCommand
                 {
                     if (allowPrerelease || !sdk.Version.IsPrerelease)
                     {
-                        sdks.Add(sdk);
+                        releases.Add(release);
                     }
                 }
             }
         }
         // Sort in descending order.
-        sdks.Sort((a, b) => b.Version.CompareSortOrderTo(a.Version));
-        return sdks;
+        releases.Sort((a, b) => b.Sdk.Version.CompareSortOrderTo(a.Sdk.Version));
+        return releases;
     }
 }

--- a/src/dnvm/RestoreCommand.cs
+++ b/src/dnvm/RestoreCommand.cs
@@ -285,6 +285,12 @@ public static partial class RestoreCommand
                 return Error.IoError; // Result.ManifestIOError;
             }
 
+            if (!options.Force && ManifestUtils.IsSdkInstalled(manifest, release.Sdk.Version, manifest.CurrentSdkDir))
+            {
+                logger.Log($"Version {release.Sdk.Version} is already installed in directory '{manifest.CurrentSdkDir.Name}'." +
+                    " Skipping installation. To install anyway, pass --force.");
+                return release.Sdk.Version;
+            }
 
             var error = await InstallCommand.InstallSdk(env, manifest, release.Sdk, release, manifest.CurrentSdkDir, logger);
             if (error is not Result<Manifest, InstallError>.Ok)

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -448,12 +448,15 @@ Options:
             console,
             [ "restore", param ]));
         Assert.Equal("""
-usage: dnvm restore [-h | --help]
+usage: dnvm restore [-l | --local] [-f | --force] [-v | --verbose] [-h | --help]
 
-Downloads the SDK in the global.json in or above the current directory to the
-.dotnet folder in the same directory.
+Downloads the SDK in the global.json in or above the current directory.
 
 Options:
+    -l, --local  Install the sdk into the .dotnet folder in the same directory
+as global.json.
+    -f, --force  Force install the SDK, even if already installed.
+    -v, --verbose  Print extra debugging info to the console.
     -h, --help  Show help information.
 
 

--- a/test/UnitTests/RestoreTests.cs
+++ b/test/UnitTests/RestoreTests.cs
@@ -67,7 +67,8 @@ public sealed class RestoreTests
 
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -75,6 +76,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -96,7 +101,8 @@ public sealed class RestoreTests
 
         Assert.False(env.CwdFs.DirectoryExists(UPath.Root / ".dotnet"));
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(UPath.Root / ".dotnet"));
@@ -104,6 +110,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(UPath.Root / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -125,7 +135,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 43);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -133,6 +144,11 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -155,7 +171,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 43);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -163,6 +180,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -186,7 +207,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 100), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 100);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -194,6 +216,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -218,7 +244,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 43, 0), restoreResult);
+        var expectedVersion = new SemVersion(42, 43, 0);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -226,6 +253,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -251,7 +282,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), restoreResult);
+        var expectedVersion = SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -259,6 +291,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -285,7 +321,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(SemVersion.Parse("43.0.0", SemVersionStyles.Strict), restoreResult);
+        var expectedVersion = SemVersion.Parse("43.0.0", SemVersionStyles.Strict);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
 
         {
@@ -294,6 +331,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -316,7 +357,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -324,6 +366,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -347,7 +393,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -355,6 +402,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -379,7 +430,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -387,6 +439,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -412,7 +468,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(SemVersion.Parse("42.42.42", SemVersionStyles.Strict), restoreResult);
+        var expectedVersion = SemVersion.Parse("42.42.42", SemVersionStyles.Strict);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -420,6 +477,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -443,7 +504,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 43), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 43);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -451,6 +513,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -474,7 +540,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 42, 100), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 100);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -482,6 +549,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -506,7 +577,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(new SemVersion(42, 43, 0), restoreResult);
+        var expectedVersion = new SemVersion(42, 43, 0);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -514,6 +586,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -539,7 +615,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict), restoreResult);
+        var expectedVersion = SemVersion.Parse("99.99.99-preview", SemVersionStyles.Strict);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -547,6 +624,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -573,7 +654,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-        Assert.Equal(SemVersion.Parse("43.0.0", SemVersionStyles.Strict), restoreResult);
+        var expectedVersion = SemVersion.Parse("43.0.0", SemVersionStyles.Strict);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -581,6 +663,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 
@@ -613,8 +699,8 @@ public sealed class RestoreTests
         Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
 
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
-
-        Assert.Equal(new SemVersion(42, 42, 42), restoreResult);
+        var expectedVersion = new SemVersion(42, 42, 42);
+        Assert.Equal(expectedVersion, restoreResult);
         if (isLocalInstall)
         {
             Assert.True(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
@@ -622,6 +708,10 @@ public sealed class RestoreTests
         else
         {
             Assert.False(env.CwdFs.DirectoryExists(env.Cwd / ".dotnet"));
+
+            var manifest = await env.ReadManifest();
+            var expectedManifest = Manifest.Empty.AddSdk(expectedVersion);
+            Assert.Equal(expectedManifest, manifest);
         }
     });
 }


### PR DESCRIPTION
This changes the behavior of `dnvm restore`.

Before, restore always did a local restore to the .dotnet directory that matched the global.json. Now the default behavior is to install to the "global" dnvm directory for the user.

This is likely a better default because it allows the user to use `dnvm restore` across many repos without installing duplicate SDK versions. The previous behavior is available via `--local|-l`.

I also added a log statement to show the global.json parsed and roll forward calculated values. A few times I forgot about roll forward rules and got unexpected results, so the log statement helps explain where blame resides 🙃.