### PR TITLE
Remove commandlinearguments record

### DIFF
--- a/src/Serde.CmdLine/Serde.CmdLine.csproj
+++ b/src/Serde.CmdLine/Serde.CmdLine.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Serde" />
     <PackageReference Include="Spectre.Console" />
 
+    <PackageReference Include="StaticCs" />
     <PackageReference Include="StaticCs.Result" />
 
   </ItemGroup>

--- a/src/dnvm/CommandLineArguments.cs
+++ b/src/dnvm/CommandLineArguments.cs
@@ -14,13 +14,13 @@ namespace Dnvm;
 
 [GenerateDeserialize]
 [Command("dnvm", Summary = "Install and manage .NET SDKs.")]
-public partial record DnvmCommand
+public partial record DnvmArgs
 {
     [CommandOption("--enable-dnvm-previews", Description = "Enable dnvm previews.")]
     public bool? EnableDnvmPreviews { get; init; }
 
     [CommandGroup("command")]
-    public DnvmSubCommand? Command { get; init; }
+    public DnvmSubCommand? SubCommand { get; init; }
 }
 
 [Closed]
@@ -30,7 +30,7 @@ public abstract partial record DnvmSubCommand
     private DnvmSubCommand() { }
 
     [Command("install", Summary = "Install an SDK.")]
-    public sealed partial record InstallCommand : DnvmSubCommand
+    public sealed partial record InstallArgs : DnvmSubCommand
     {
         [CommandParameter(0, "version", Description = "The version of the SDK to install.")]
         [SerdeMemberOptions(DeserializeProxy = typeof(SemVersionProxy))]
@@ -48,7 +48,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("track", Summary = "Start tracking a new channel.")]
-    public sealed partial record TrackCommand : DnvmSubCommand
+    public sealed partial record TrackArgs : DnvmSubCommand
     {
         [CommandParameter(0, "channel", Description = "Track the channel specified.")]
         [SerdeMemberOptions(DeserializeProxy = typeof(CaseInsensitiveChannel))]
@@ -85,7 +85,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("selfinstall", Summary = "Install dnvm to the local machine.")]
-    public sealed partial record SelfInstallCommand : DnvmSubCommand
+    public sealed partial record SelfInstallArgs : DnvmSubCommand
     {
         [CommandOption("-v|--verbose", Description = "Print debugging messages to the console.")]
         public bool? Verbose { get; init; } = null;
@@ -107,7 +107,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("update", Summary = "Update the installed SDKs or dnvm itself.")]
-    public sealed partial record UpdateCommand : DnvmSubCommand
+    public sealed partial record UpdateArgs : DnvmSubCommand
     {
         [CommandOption("--dnvm-url", Description = "Set the URL for the dnvm releases endpoint.")]
         public string? DnvmReleasesUrl { get; init; } = null;
@@ -126,7 +126,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("list", Summary = "List installed SDKs.")]
-    public sealed partial record ListCommand : DnvmSubCommand
+    public sealed partial record ListArgs : DnvmSubCommand
     {
     }
 
@@ -137,14 +137,14 @@ public abstract partial record DnvmSubCommand
 "Note: This command does not change between SDK versions installed in the same directory. For " +
 "that, use the built-in dotnet global.json file. Information about global.json can be found at " +
 "https://learn.microsoft.com/en-us/dotnet/core/tools/global-json.")]
-    public sealed partial record SelectCommand : DnvmSubCommand
+    public sealed partial record SelectArgs : DnvmSubCommand
     {
         [CommandParameter(0, "sdkDirName", Description = "The name of the SDK directory to select.")]
         public required string SdkDirName { get; init; }
     }
 
     [Command("untrack", Summary = "Remove a channel from the list of tracked channels.")]
-    public sealed partial record UntrackCommand : DnvmSubCommand
+    public sealed partial record UntrackArgs : DnvmSubCommand
     {
         [CommandParameter(0, "channel", Description = "The channel to untrack.")]
         [SerdeMemberOptions(DeserializeProxy = typeof(CaseInsensitiveChannel))]
@@ -152,7 +152,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("uninstall", Summary = "Uninstall an SDK.")]
-    public sealed partial record UninstallCommand : DnvmSubCommand
+    public sealed partial record UninstallArgs : DnvmSubCommand
     {
         [CommandParameter(0, "sdkVersion", Description = "The version of the SDK to uninstall.")]
         [SerdeMemberOptions(DeserializeProxy = typeof(SemVersionProxy))]
@@ -164,7 +164,7 @@ public abstract partial record DnvmSubCommand
     }
 
     [Command("prune", Summary = "Remove all SDKs with older patch versions.")]
-    public sealed partial record PruneCommand : DnvmSubCommand
+    public sealed partial record PruneArgs : DnvmSubCommand
     {
         [CommandOption("-v|--verbose", Description = "Print extra debugging info to the console.")]
         public bool? Verbose { get; init; } = null;
@@ -175,7 +175,7 @@ public abstract partial record DnvmSubCommand
 
     [Command("restore", Summary = "Restore the SDK listed in the global.json file.",
         Description = "Downloads the SDK in the global.json in or above the current directory to the .dotnet folder in the same directory.")]
-    public sealed partial record RestoreCommand : DnvmSubCommand
+    public sealed partial record RestoreArgs : DnvmSubCommand
     {
     }
 
@@ -207,117 +207,12 @@ public abstract partial record DnvmSubCommand
     }
 }
 
-[Closed]
-public abstract record CommandArguments
+public static class CommandLineArguments
 {
-    private CommandArguments() {}
-
-    public sealed record InstallArguments : CommandArguments
-    {
-        public required SemVersion SdkVersion { get; init; }
-        public bool Force { get; init; } = false;
-        public SdkDirName? SdkDir { get; init; } = null;
-        public bool Verbose { get; init; } = false;
-    }
-
-    public sealed record TrackArguments : CommandArguments
-    {
-        public required Channel Channel { get; init; }
-        /// <summary>
-        /// URL to the dotnet feed containing the releases index and SDKs.
-        /// </summary>
-        public string? FeedUrl { get; init; }
-        public bool Verbose { get; init; } = false;
-        public bool Force { get; init; } = false;
-        /// <summary>
-        /// Answer yes to every question or use the defaults.
-        /// </summary>
-        public bool Yes { get; init; } = false;
-        public bool Prereqs { get; init; } = false;
-        /// <summary>
-        /// When specified, install the SDK into a separate directory with the given name,
-        /// translated to lower-case. Preview releases are installed into a directory named 'preview'
-        /// by default.
-        /// </summary>
-        public string? SdkDir { get; init; } = null;
-    }
-
-    public sealed record SelfInstallArguments : CommandArguments
-    {
-        public bool Verbose { get; init; } = false;
-        public bool Force { get; init; } = false;
-        /// <summary>
-        /// URL to the dotnet feed containing the releases index and download artifacts.
-        /// </summary>
-        public string? FeedUrl { get; init; }
-        /// <summary>
-        /// Answer yes to every question or use the defaults.
-        /// </summary>
-        public bool Yes { get; init; } = false;
-        /// <summary>
-        /// When true, add dnvm update lines to the user's config files
-        /// or environment variables.
-        /// </summary>
-        public bool UpdateUserEnvironment { get; init; } = true;
-        /// <summary>
-        /// Indicates that this is an update to an existing dnvm installation.
-        /// </summary>
-        public bool Update { get; init; } = false;
-        /// <summary>
-        /// Path to overwrite.
-        /// </summary>
-        public string? DestPath { get; init; } = null;
-    }
-
-    public sealed record UpdateArguments : CommandArguments
-    {
-        /// <summary>
-        /// URL to the dnvm releases.json file listing the latest releases and their download
-        /// locations.
-        /// </summary>
-        public string? DnvmReleasesUrl { get; init; }
-        public string? FeedUrl { get; init; }
-        public bool Verbose { get; init; } = false;
-        public bool Self { get; init; } = false;
-        /// <summary>
-        /// Implicitly answers 'yes' to every question.
-        /// </summary>
-        public bool Yes { get; init; } = false;
-    }
-
-    public sealed record ListArguments : CommandArguments
-    { }
-
-    public sealed record SelectArguments : CommandArguments
-    {
-        public required string SdkDirName { get; init; }
-    }
-
-    public sealed record UntrackArguments : CommandArguments
-    {
-        public required Channel Channel { get; init; }
-    }
-
-    public sealed record UninstallArguments : CommandArguments
-    {
-        public required SemVersion SdkVersion { get; init; }
-        public SdkDirName? Dir { get; init; } = null;
-    }
-
-    public sealed record PruneArguments : CommandArguments
-    {
-        public bool Verbose { get; init; } = false;
-        public bool DryRun { get; init; } = false;
-    }
-
-    public sealed record RestoreArguments : CommandArguments;
-}
-
-public sealed record class CommandLineArguments(CommandArguments? Command)
-{
-    public bool EnableDnvmPreviews { get; init; } = false;
-
-    public static CommandLineArguments? TryParse(IAnsiConsole console, string[] args)
+    /// <summary>
+    /// Returns null if an error was produced or help was requested.
+    /// </summary>
+    public static DnvmArgs? TryParse(IAnsiConsole console, string[] args)
     {
         try
         {
@@ -326,123 +221,35 @@ public sealed record class CommandLineArguments(CommandArguments? Command)
         catch (ArgumentSyntaxException ex)
         {
             console.WriteLine("error: " + ex.Message);
-            console.WriteLine(CmdLine.GetHelpText(SerdeInfoProvider.GetDeserializeInfo<DnvmCommand>(), includeHelp: true));
+            console.WriteLine(CmdLine.GetHelpText<DnvmArgs>(includeHelp: true));
             return null;
         }
     }
 
     /// <summary>
-    /// Throws an exception if the command was not recognized.
+    /// Throws an exception if the command was not recognized. Returns null if help was requested.
     /// </summary>
-    public static CommandLineArguments ParseRaw(IAnsiConsole console, string[] args)
+    public static DnvmArgs? ParseRaw(IAnsiConsole console, string[] args)
     {
-        var result = CmdLine.ParseRaw<DnvmCommand>(args, handleHelp: true);
-        DnvmCommand dnvmCmd;
+        var result = CmdLine.ParseRawWithHelp<DnvmArgs>(args);
+        DnvmArgs dnvmCmd;
         switch (result)
         {
-            case Result<DnvmCommand, IReadOnlyList<ISerdeInfo>>.Ok(var value):
+            case CmdLine.ParsedArgsOrHelpInfos<DnvmArgs>.Parsed(var value):
                 dnvmCmd = value;
-                break;
-            case Result<DnvmCommand, IReadOnlyList<ISerdeInfo>>.Err(var helpInfos):
-                var rootInfo = SerdeInfoProvider.GetDeserializeInfo<DnvmCommand>();
+                if (dnvmCmd.EnableDnvmPreviews is null && dnvmCmd.SubCommand is null)
+                {
+                    // Empty command is a help request.
+                    console.WriteLine(CmdLine.GetHelpText<DnvmArgs>(includeHelp: true));
+                }
+                return dnvmCmd;
+            case CmdLine.ParsedArgsOrHelpInfos<DnvmArgs>.Help(var helpInfos):
+                var rootInfo = SerdeInfoProvider.GetDeserializeInfo<DnvmArgs>();
                 var lastInfo = helpInfos.Last();
                 console.WriteLine(CmdLine.GetHelpText(rootInfo, lastInfo, includeHelp: true));
-                return new CommandLineArguments(Command: null);
+                return null;
             default:
                 throw new InvalidOperationException();
         }
-        if (dnvmCmd.EnableDnvmPreviews == true)
-        {
-            return new CommandLineArguments(Command: null) {
-                EnableDnvmPreviews = true
-            };
-        }
-        switch (dnvmCmd.Command)
-        {
-            case DnvmSubCommand.ListCommand c:
-            {
-                return new CommandLineArguments(new CommandArguments.ListArguments());
-            }
-            case DnvmSubCommand.SelectCommand s:
-            {
-                return new CommandLineArguments(new CommandArguments.SelectArguments { SdkDirName = s.SdkDirName });
-            }
-            case DnvmSubCommand.UntrackCommand u:
-            {
-                return new CommandLineArguments(new CommandArguments.UntrackArguments { Channel = u.Channel });
-            }
-            case DnvmSubCommand.InstallCommand i:
-            {
-                return new CommandLineArguments(new CommandArguments.InstallArguments
-                {
-                    SdkVersion = i.SdkVersion,
-                    Force = i.Force ?? false,
-                    SdkDir = i.SdkDir,
-                    Verbose = i.Verbose ?? false,
-                });
-            }
-            case DnvmSubCommand.TrackCommand t:
-            {
-                return new CommandLineArguments(new CommandArguments.TrackArguments
-                {
-                    Channel = t.Channel,
-                    Verbose = t.Verbose ?? false,
-                    Force = t.Force ?? false,
-                    Yes = t.Yes ?? false,
-                    Prereqs = t.Prereqs ?? false,
-                    FeedUrl = t.FeedUrl,
-                    SdkDir = t.SdkDir,
-                });
-            }
-            case DnvmSubCommand.SelfInstallCommand s:
-            {
-                return new CommandLineArguments(new CommandArguments.SelfInstallArguments
-                {
-                    Verbose = s.Verbose ?? false,
-                    Yes = s.Yes ?? false,
-                    FeedUrl = s.FeedUrl,
-                    Force = s.Force ?? false,
-                    Update = s.Update ?? false,
-                    DestPath = s.DestPath,
-                });
-            }
-            case DnvmSubCommand.UpdateCommand u:
-            {
-                return new CommandLineArguments(new CommandArguments.UpdateArguments
-                {
-                    Self = u.Self ?? false,
-                    Verbose = u.Verbose ?? false,
-                    FeedUrl = u.FeedUrl,
-                    DnvmReleasesUrl = u.DnvmReleasesUrl,
-                });
-            }
-            case DnvmSubCommand.UninstallCommand u:
-            {
-                return new CommandLineArguments(new CommandArguments.UninstallArguments
-                {
-                    SdkVersion = u.SdkVersion,
-                    Dir = u.SdkDir,
-                });
-            }
-            case DnvmSubCommand.PruneCommand p:
-            {
-                return new CommandLineArguments(new CommandArguments.PruneArguments
-                {
-                    Verbose = p.Verbose ?? false,
-                    DryRun = p.DryRun ?? false,
-                });
-            }
-            case DnvmSubCommand.RestoreCommand r:
-            {
-                return new CommandLineArguments(new CommandArguments.RestoreArguments());
-            }
-            case null:
-            {
-                console.WriteLine(CmdLine.GetHelpText(SerdeInfoProvider.GetDeserializeInfo<DnvmCommand>(), includeHelp: true));
-                return new CommandLineArguments(Command: null);
-            }
-        }
-
-        throw new DeserializeException("Unknown command");
     }
 }

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -25,7 +25,27 @@ public static partial class InstallCommand
         ManifestIOError,
         InstallError
     }
-    public static async Task<Result> Run(DnvmEnv env, Logger logger, CommandArguments.InstallArguments options)
+
+    public sealed record Options
+    {
+        public required SemVersion SdkVersion { get; init; }
+        public bool Force { get; init; } = false;
+        public SdkDirName? SdkDir { get; init; } = null;
+        public bool Verbose { get; init; } = false;
+    }
+
+    public static Task<Result> Run(DnvmEnv env, Logger logger, DnvmSubCommand.InstallArgs args)
+    {
+        return Run(env, logger, new Options
+        {
+            SdkVersion = args.SdkVersion,
+            Force = args.Force ?? false,
+            SdkDir = args.SdkDir,
+            Verbose = args.Verbose ?? false,
+        });
+    }
+
+    public static async Task<Result> Run(DnvmEnv env, Logger logger, Options options)
     {
         var sdkDir = options.SdkDir ?? DnvmEnv.DefaultSdkDirName;
 

--- a/src/dnvm/SelectCommand.cs
+++ b/src/dnvm/SelectCommand.cs
@@ -18,11 +18,10 @@ public static class SelectCommand
         BadDirName,
     }
 
-    public static async Task<Result> Run(DnvmEnv dnvmEnv, Logger logger, CommandArguments.SelectArguments args)
+    public static async Task<Result> Run(DnvmEnv dnvmEnv, Logger logger, SdkDirName sdkDirName)
     {
-        var newDir = new SdkDirName(args.SdkDirName);
         var manifest = await dnvmEnv.ReadManifest();
-        switch (await RunWithManifest(dnvmEnv, newDir, manifest, logger))
+        switch (await RunWithManifest(dnvmEnv, sdkDirName, manifest, logger))
         {
             case Result<Manifest, Result>.Ok(var newManifest):
                 dnvmEnv.WriteManifest(newManifest);

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -10,7 +10,7 @@ namespace Dnvm;
 
 public sealed class UninstallCommand
 {
-    public static async Task<int> Run(DnvmEnv env, Logger logger, CommandArguments.UninstallArguments args)
+    public static async Task<int> Run(DnvmEnv env, Logger logger, SemVersion sdkVersion, SdkDirName? dir = null)
     {
         Manifest manifest;
         try
@@ -33,7 +33,7 @@ public sealed class UninstallCommand
 
         foreach (var installed in manifest.InstalledSdks)
         {
-            if (installed.SdkVersion == args.SdkVersion && (args.Dir is null || installed.SdkDirName == args.Dir))
+            if (installed.SdkVersion == sdkVersion && (dir is null || installed.SdkDirName == dir))
             {
                 sdksToRemove.Add((installed.SdkVersion, installed.SdkDirName));
                 runtimesToRemove.Add((installed.RuntimeVersion, installed.SdkDirName));
@@ -50,7 +50,7 @@ public sealed class UninstallCommand
 
         if (sdksToRemove.Count == 0)
         {
-            logger.Error($"SDK version {args.SdkVersion} is not installed.");
+            logger.Error($"SDK version {sdkVersion} is not installed.");
             return 1;
         }
 
@@ -63,7 +63,7 @@ public sealed class UninstallCommand
         DeleteAspnets(env, aspnetToRemove, logger);
         DeleteWins(env, winToRemove, logger);
 
-        manifest = UninstallSdk(manifest, args.SdkVersion);
+        manifest = UninstallSdk(manifest, sdkVersion);
         env.WriteManifest(manifest);
 
         return 0;

--- a/src/dnvm/UntrackCommand.cs
+++ b/src/dnvm/UntrackCommand.cs
@@ -17,7 +17,7 @@ public sealed class UntrackCommand
         public record ManifestReadError : Result;
     }
 
-    public static async Task<int> Run(DnvmEnv env, Logger logger, CommandArguments.UntrackArguments options)
+    public static async Task<int> Run(DnvmEnv env, Logger logger, Channel channel)
     {
         Manifest manifest;
         try
@@ -29,7 +29,7 @@ public sealed class UntrackCommand
             logger.Log("Failed to read manifest file");
             return 1;
         }
-        var result = RunHelper(options.Channel, manifest, logger);
+        var result = RunHelper(channel, manifest, logger);
         if (result is Result.Success({} newManifest))
         {
             env.WriteManifest(newManifest);

--- a/test/Serde.CmdLine.Test/CliTests.cs
+++ b/test/Serde.CmdLine.Test/CliTests.cs
@@ -12,7 +12,7 @@ public sealed partial class DeserializerTests
     public void SpectreExample()
     {
         string[] testArgs = [ "-p", "*.txt", "--hidden", ];
-        var cmd = CmdLine.ParseRaw<FileSizeCommand>(testArgs).Unwrap();
+        var cmd = CmdLine.ParseRawWithHelp<FileSizeCommand>(testArgs).Unwrap();
         Assert.Equal(new FileSizeCommand { SearchPath = null, SearchPattern = "*.txt", IncludeHidden = true }, cmd);
     }
 
@@ -20,7 +20,7 @@ public sealed partial class DeserializerTests
     public void TestSearchPath()
     {
         string[] testArgs = [ "search-path" ];
-        var cmd = CmdLine.ParseRaw<FileSizeCommand>(testArgs).Unwrap();
+        var cmd = CmdLine.ParseRawWithHelp<FileSizeCommand>(testArgs).Unwrap();
         Assert.Equal(new FileSizeCommand { SearchPath = "search-path", SearchPattern = null, IncludeHidden = null }, cmd);
     }
 
@@ -98,7 +98,7 @@ Options:
     public void BasicCommandTest()
     {
         string[] cmdLine = [ "-f", "abc" ];
-        var cmd = CmdLine.ParseRaw<BasicCommand>(cmdLine).Unwrap();
+        var cmd = CmdLine.ParseRawWithHelp<BasicCommand>(cmdLine).Unwrap();
         Assert.Equal(new BasicCommand
         {
             FlagOption = true,

--- a/test/Serde.CmdLine.Test/ParsedArgsOrHelpInfosExt.cs
+++ b/test/Serde.CmdLine.Test/ParsedArgsOrHelpInfosExt.cs
@@ -1,0 +1,11 @@
+using static Serde.CmdLine.CmdLine;
+
+namespace Serde.CmdLine.Test;
+
+public static class ParsedArgsOrHelpInfosExt
+{
+    public static T Unwrap<T>(this ParsedArgsOrHelpInfos<T> @this)
+    {
+        return ((ParsedArgsOrHelpInfos<T>.Parsed)@this).Args;
+    }
+}

--- a/test/Serde.CmdLine.Test/SubCommandTests.cs
+++ b/test/Serde.CmdLine.Test/SubCommandTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Spectre.Console.Testing;
 using Xunit;
 
-namespace Serde.CmdLine;
+namespace Serde.CmdLine.Test;
 
 public sealed partial class SubCommandTests
 {
@@ -12,7 +12,7 @@ public sealed partial class SubCommandTests
     public void NoSubCommand()
     {
         string[] testArgs = [ "-v" ];
-        var cmd = CmdLine.ParseRaw<TopCommand>(testArgs).Unwrap();
+        var cmd = CmdLine.ParseRawWithHelp<TopCommand>(testArgs).Unwrap();
         Assert.Equal(new TopCommand { Verbose = true, SubCommand = null }, cmd);
     }
 
@@ -20,7 +20,7 @@ public sealed partial class SubCommandTests
     public void FirstCommand()
     {
         string[] testArgs = [ "-v", "first" ];
-        var cmd = CmdLine.ParseRaw<TopCommand>(testArgs).Unwrap();
+        var cmd = CmdLine.ParseRawWithHelp<TopCommand>(testArgs).Unwrap();
         Assert.Equal(new TopCommand { Verbose = true, SubCommand = new SubCommand.FirstCommand() }, cmd);
     }
 

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -37,7 +37,8 @@ public sealed class CommandLineTests
     {
         var console = new TestConsole();
         var options = CommandLineArguments.ParseRaw(console, []);
-        Assert.Null(options.Command);
+        Assert.NotNull(options);
+        Assert.Null(options.SubCommand);
         Assert.Equal(ExpectedHelpText, console.Output);
     }
 
@@ -47,7 +48,7 @@ public sealed class CommandLineTests
         var options = CommandLineArguments.ParseRaw(new TestConsole(), [
             "restore"
         ]);
-        Assert.True(options!.Command is CommandArguments.RestoreArguments);
+        Assert.True(options!.SubCommand is DnvmSubCommand.RestoreArgs);
     }
 
     [Fact]
@@ -56,7 +57,7 @@ public sealed class CommandLineTests
         var options = CommandLineArguments.ParseRaw(new TestConsole(), [
             "list"
         ]);
-        Assert.True(options!.Command is CommandArguments.ListArguments);
+        Assert.True(options!.SubCommand is DnvmSubCommand.ListArgs);
     }
 
     [Fact]
@@ -66,7 +67,7 @@ public sealed class CommandLineTests
             "select",
             "preview"
         ]);
-        Assert.True(options!.Command is CommandArguments.SelectArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.SelectArgs {
             SdkDirName: "preview"
         });
     }
@@ -86,7 +87,7 @@ public sealed class CommandLineTests
             "track",
             "99.99"
         ]);
-        Assert.True(options!.Command is CommandArguments.TrackArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.TrackArgs {
             Channel: Channel.VersionedMajorMinor { Major: 99, Minor: 99 }
         });
     }
@@ -98,7 +99,7 @@ public sealed class CommandLineTests
             "track",
             "99.99.9xx"
         ]);
-        Assert.True(options!.Command is CommandArguments.TrackArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.TrackArgs {
             Channel: Channel.VersionedFeature { Major: 99, Minor: 99, FeatureLevel: 9 }
         });
     }
@@ -132,7 +133,7 @@ Channel must be one of:
             "install",
             MockServer.DefaultLtsVersion.ToString(),
         ]);
-        Assert.True(options!.Command is CommandArguments.InstallArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.InstallArgs {
             SdkVersion: var sdkVersion
         } && sdkVersion == MockServer.DefaultLtsVersion);
     }
@@ -147,7 +148,7 @@ Channel must be one of:
             "-v",
             MockServer.DefaultLtsVersion.ToString(),
         ]);
-        Assert.True(options!.Command is CommandArguments.InstallArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.InstallArgs {
             SdkVersion: var sdkVersion,
             Force: true,
             SdkDir: {} sdkDir,
@@ -171,7 +172,7 @@ Channel must be one of:
             "track",
             "lTs"
         ]);
-        Assert.True(options!.Command is CommandArguments.TrackArguments {
+        Assert.True(options!.SubCommand is DnvmSubCommand.TrackArgs {
             Channel: Channel.Lts
         });
     }
@@ -191,7 +192,7 @@ Channel must be one of:
     public void RunHelp(string param)
     {
         var console = new TestConsole();
-        Assert.Null(CommandLineArguments.ParseRaw(console, [ param ]).Command);
+        Assert.Null(CommandLineArguments.ParseRaw(console, [ param ]));
         Assert.Equal(ExpectedHelpText, console.Output);
     }
 
@@ -203,7 +204,7 @@ Channel must be one of:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "list", param ]).Command);
+            [ "list", param ]));
         Assert.Equal("""
 usage: dnvm list [-h | --help]
 
@@ -224,7 +225,7 @@ Options:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "select", param ]).Command);
+            [ "select", param ]));
         Assert.Equal("""
 usage: dnvm select [-h | --help] <sdkDirName>
 
@@ -255,7 +256,7 @@ Options:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "install", param ]).Command);
+            [ "install", param ]));
         Assert.Equal("""
 usage: dnvm install [-f | --force] [-s | --sdk-dir <sdkDir>] [-v | --verbose]
 [-h | --help] <version>
@@ -284,7 +285,7 @@ given name.
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "track", param ]).Command);
+            [ "track", param ]));
         Assert.Equal("""
 usage: dnvm track [--feed-url <feedUrl>] [-v | --verbose] [-f | --force] [-y]
 [--prereqs] [-s | --sdk-dir <sdkDir>] [-h | --help] <channel>
@@ -316,7 +317,7 @@ given name.
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "selfinstall", param ]).Command);
+            [ "selfinstall", param ]));
         Assert.Equal("""
 usage: dnvm selfinstall [-v | --verbose] [-f | --force] [--feed-url <feedUrl>]
 [-y] [--update] [--dest-path <destPath>] [-h | --help]
@@ -345,7 +346,7 @@ be called from dnvm.
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "update", param ]).Command);
+            [ "update", param ]));
         Assert.Equal("""
 usage: dnvm update [--dnvm-url <dnvmReleasesUrl>] [--feed-url <feedUrl>] [-v |
 --verbose] [--self] [-y] [-h | --help]
@@ -372,7 +373,7 @@ Options:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "uninstall", param ]).Command);
+            [ "uninstall", param ]));
         Assert.Equal("""
 usage: dnvm uninstall [-s | --sdk-dir <sdkDir>] [-h | --help] <sdkVersion>
 
@@ -397,7 +398,7 @@ Options:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "prune", param ]).Command);
+            [ "prune", param ]));
         Assert.Equal("""
 usage: dnvm prune [-v | --verbose] [--dry-run] [-h | --help]
 
@@ -421,7 +422,7 @@ uninstall.
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "untrack", param ]).Command);
+            [ "untrack", param ]));
         Assert.Equal("""
 usage: dnvm untrack [-h | --help] <channel>
 
@@ -445,7 +446,7 @@ Options:
         var console = new TestConsole();
         Assert.Null(CommandLineArguments.ParseRaw(
             console,
-            [ "restore", param ]).Command);
+            [ "restore", param ]));
         Assert.Equal("""
 usage: dnvm restore [-h | --help]
 

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -19,7 +19,7 @@ public sealed class InstallTests
         Assert.False(env.DnvmHomeFs.FileExists(dotnetFile));
 
         var logger = new Logger(new TestConsole());
-        var options = new CommandArguments.InstallArguments()
+        var options = new DnvmSubCommand.InstallArgs
         {
             SdkVersion = MockServer.DefaultLtsVersion
         };
@@ -38,7 +38,7 @@ public sealed class InstallTests
     {
         var console = new TestConsole();
         var logger = new Logger(console);
-        var options = new CommandArguments.InstallArguments()
+        var options = new DnvmSubCommand.InstallArgs
         {
             SdkVersion = MockServer.DefaultLtsVersion,
         };
@@ -59,7 +59,7 @@ public sealed class InstallTests
     {
         var console = new TestConsole();
         var logger = new Logger(console);
-        var options = new CommandArguments.InstallArguments()
+        var options = new DnvmSubCommand.InstallArgs
         {
             SdkVersion = MockServer.DefaultLtsVersion,
             Force = true,
@@ -82,9 +82,10 @@ public sealed class InstallTests
     {
         var console = new TestConsole();
         var logger = new Logger(console);
-        var options = new CommandArguments.InstallArguments()
+        var options = new DnvmSubCommand.InstallArgs
         {
             SdkVersion = MockServer.DefaultLtsVersion,
+            Verbose = true,
         };
         var installResult = await InstallCommand.Run(env, logger, options);
         Assert.Equal(InstallCommand.Result.Success, installResult);
@@ -103,7 +104,7 @@ public sealed class InstallTests
         var logger = new Logger(console);
         var previewVersion = SemVersion("192.192.192-preview");
         server.RegisterDailyBuild(previewVersion);
-        var options = new CommandArguments.InstallArguments()
+        var options = new DnvmSubCommand.InstallArgs
         {
             SdkVersion = previewVersion
         };
@@ -155,7 +156,7 @@ public sealed class InstallTests
             var logger = new Logger(console);
             var previewVersion = SemVersion("192.192.192-preview");
             server.RegisterDailyBuild(previewVersion);
-            var options = new CommandArguments.InstallArguments()
+            var options = new DnvmSubCommand.InstallArgs
             {
                 SdkVersion = previewVersion
             };
@@ -276,7 +277,7 @@ public sealed class InstallTests
 
         var console = new TestConsole();
         var logger = new Logger(console);
-        var result = await InstallCommand.Run(env, logger, new()
+        var result = await InstallCommand.Run(env, logger, new InstallCommand.Options()
         {
             SdkVersion = SemVersion("42.42.100")
         });

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -18,7 +18,7 @@ public sealed class SelectTests
     [Fact]
     public Task SelectPreview() => TestUtils.RunWithServer(async (mockServer, env) =>
     {
-        var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Latest(),
         });
@@ -27,7 +27,7 @@ public sealed class SelectTests
         var defaultSdkDir = DnvmEnv.DefaultSdkDirName;
         var defaultDotnet = DnvmEnv.GetSdkPath(defaultSdkDir) / Utilities.DotnetExeName;
         Assert.True(homeFs.FileExists(defaultDotnet));
-        result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Preview(),
         });

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -15,15 +15,15 @@ public sealed class UninstallTests
     [Fact]
     public Task LtsAndPreview() => RunWithServer(async (server, env) =>
     {
-        var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Preview(),
-            SdkDir = "preview"
+            SdkDir = new("preview")
         });
         Assert.Equal(TrackCommand.Result.Success, result);
         var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[0].LatestSdk, SemVersionStyles.Strict);
@@ -33,10 +33,7 @@ public sealed class UninstallTests
             .AddSdk(previewVersion, new Channel.Preview(), new SdkDirName("preview"));
         var manifest = await env.ReadManifest();
         Assert.Equal(expectedManifest, manifest);
-        var unResult = await UninstallCommand.Run(env, _logger, new CommandArguments.UninstallArguments
-        {
-            SdkVersion = ltsVersion
-        });
+        var unResult = await UninstallCommand.Run(env, _logger, ltsVersion);
         Assert.Equal(0, unResult);
         manifest = await env.ReadManifest();
         var previewOnly = Manifest.Empty
@@ -61,12 +58,12 @@ public sealed class UninstallTests
     [Fact]
     public Task UninstallMessage() => RunWithServer(async (server, env) =>
     {
-        var result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Latest(),
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        result = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        result = await TrackCommand.Run(env, _logger, new DnvmSubCommand.TrackArgs
         {
             Channel = new Channel.Preview(),
             SdkDir = "preview"
@@ -77,10 +74,7 @@ public sealed class UninstallTests
         var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[1].LatestSdk, SemVersionStyles.Strict);
 
         var uninstallConsole = new TestConsole();
-        var unResult = await UninstallCommand.Run(env, new Logger(uninstallConsole), new CommandArguments.UninstallArguments
-        {
-            SdkVersion = previewVersion
-        });
+        var unResult = await UninstallCommand.Run(env, new Logger(uninstallConsole), previewVersion);
         Assert.Equal(0, unResult);
         Assert.DoesNotContain("SdkDirName", uninstallConsole.Output);
         Assert.DoesNotContain(ltsVersion.ToString(), uninstallConsole.Output);

--- a/test/UnitTests/UntrackTests.cs
+++ b/test/UnitTests/UntrackTests.cs
@@ -50,7 +50,7 @@ public sealed class UntrackTests
     {
         var logger = new Logger(new TestConsole());
         var channel = new Channel.Latest();
-        var result = await TrackCommand.Run(env, logger, new CommandArguments.TrackArguments
+        var result = await TrackCommand.Run(env, logger, new TrackCommand.Options
         {
             Channel = channel,
             FeedUrl = mockServer.PrefixString
@@ -62,10 +62,7 @@ public sealed class UntrackTests
             ChannelName = channel,
             InstalledSdkVersions = [ MockServer.DefaultLtsVersion ],
             SdkDirName = DnvmEnv.DefaultSdkDirName }]);
-        var untrackCode = await UntrackCommand.Run(env, logger, new CommandArguments.UntrackArguments
-        {
-            Channel = channel,
-        });
+        var untrackCode = await UntrackCommand.Run(env, logger, channel);
         Assert.Equal(0, untrackCode);
     });
 
@@ -74,17 +71,14 @@ public sealed class UntrackTests
     {
         var logger = new Logger(new TestConsole());
         var channel = new Channel.Latest();
-        var result = await TrackCommand.Run(env, logger, new CommandArguments.TrackArguments
+        var result = await TrackCommand.Run(env, logger, new TrackCommand.Options
         {
             Channel = channel,
             FeedUrl = mockServer.PrefixString
         });
         Assert.Equal(TrackCommand.Result.Success, result);
 
-        var untrackCode = await UntrackCommand.Run(env, logger, new CommandArguments.UntrackArguments
-        {
-            Channel = channel,
-        });
+        var untrackCode = await UntrackCommand.Run(env, logger, channel);
         Assert.Equal(0, untrackCode);
         var manifest = await env.ReadManifest();
         var untrackResult = UntrackCommand.RunHelper(channel, manifest, logger);

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -14,7 +14,7 @@ namespace Dnvm.Test;
 public sealed class UpdateTests
 {
     private readonly Logger _logger;
-    private readonly CommandArguments.UpdateArguments updateArguments = new() {
+    private readonly DnvmSubCommand.UpdateArgs updateArguments = new() {
         Verbose = true,
         Yes = true,
     };
@@ -106,7 +106,7 @@ public sealed class UpdateTests
         var upgradeVersion = new SemVersion(41, 0, 1);
         Channel channel = new Channel.Latest();
         Setup(mockServer, baseVersion);
-        var result = await TrackCommand.Run(env, _logger, new() {
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options() {
             Channel = channel,
             Verbose = true
         });
@@ -240,14 +240,14 @@ public sealed class UpdateTests
     [Fact]
     public Task DontUpdateUntracked() => TestUtils.RunWithServer(async (server, env) =>
     {
-        var result = await TrackCommand.Run(env, _logger, new() {
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options() {
             Channel = new Channel.Latest(),
             Verbose = true
         });
 
         Assert.Equal(TrackCommand.Result.Success, result);
 
-        result = await TrackCommand.Run(env, _logger, new() {
+        result = await TrackCommand.Run(env, _logger, new TrackCommand.Options() {
             Channel = new Channel.Preview(),
             Verbose = true
         });
@@ -259,15 +259,15 @@ public sealed class UpdateTests
     {
         // Default release index only contains an LTS release, so adding LTS and latest
         // should result in the same SDK being installed
-        var result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Latest() });
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options() { Channel = new Channel.Latest() });
         Assert.Equal(TrackCommand.Result.Success , result);
-        result = await TrackCommand.Run(env, _logger, new() { Channel = new Channel.Lts() });
+        result = await TrackCommand.Run(env, _logger, new TrackCommand.Options() { Channel = new Channel.Lts() });
         Assert.Equal(TrackCommand.Result.Success , result);
 
         var oldRelease = server.ReleasesIndexJson.ChannelIndices.Single(r => r.ReleaseType == "lts");
         var newSdkVersion = new SemVersion(42, 42, 43);
         var newRelease = server.RegisterReleaseVersion(newSdkVersion, "lts", "active");
-        var updateResult = await UpdateCommand.Run(env, _logger, new() { Yes = true });
+        var updateResult = await UpdateCommand.Run(env, _logger, new UpdateCommand.Options() { Yes = true });
 
         var oldSdkVersion = SemVersion.Parse(oldRelease.LatestSdk, SemVersionStyles.Strict);
         var oldReleaseVersion = SemVersion.Parse(oldRelease.LatestRelease, SemVersionStyles.Strict);
@@ -305,7 +305,7 @@ public sealed class UpdateTests
         server.ReleasesIndexJson = DotnetReleasesIndex.Empty;
         server.ChannelIndexMap.Clear();
         server.RegisterReleaseVersion(MockServer.DefaultLtsVersion, "lts", "active");
-        var trackResult = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        var trackResult = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Preview()
         });
@@ -327,7 +327,7 @@ public sealed class UpdateTests
         server.ReleasesIndexJson = DotnetReleasesIndex.Empty;
         server.ChannelIndexMap.Clear();
         server.RegisterReleaseVersion(MockServer.DefaultLtsVersion, "lts", "active");
-        var trackResult = await TrackCommand.Run(env, _logger, new CommandArguments.TrackArguments
+        var trackResult = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = new Channel.Preview()
         });


### PR DESCRIPTION
It was mostly duplicated with the actual serialize/deserialize command object. If a particular command still needed a lot of options, a new options class was created in the command's class. Otherwise, the args now live in the former Command classes.