### PR TITLE
Colorize warnings / error messages

### DIFF
--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -82,8 +82,7 @@ public static partial class InstallCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Error("Could not fetch the releases index: ");
-            logger.Error(e.Message);
+            logger.Error($"Could not fetch the releases index: {e.Message}");
             return Result.CouldntFetchReleaseIndex;
         }
 

--- a/src/dnvm/Logger.cs
+++ b/src/dnvm/Logger.cs
@@ -20,7 +20,7 @@ public sealed record Logger(IAnsiConsole Console)
     {
         if (LogLevel >= LogLevel.Error)
         {
-            Console.MarkupLineInterpolated($"[red]Error: {msg}[/]");
+            Console.MarkupLineInterpolated($"{Environment.NewLine}[default on red]Error[/]: {msg}{Environment.NewLine}");
         }
     }
 
@@ -36,7 +36,7 @@ public sealed record Logger(IAnsiConsole Console)
     {
         if (LogLevel >= LogLevel.Warn)
         {
-            Console.MarkupLineInterpolated($"[yellow]Warning: {msg}[/]");
+            Console.MarkupLineInterpolated($"{Environment.NewLine}[default on yellow]Warning[/]: {msg}{Environment.NewLine}");
         }
     }
 

--- a/src/dnvm/Logger.cs
+++ b/src/dnvm/Logger.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security;
 using Spectre.Console;
 
 namespace Dnvm;
@@ -21,7 +20,7 @@ public sealed record Logger(IAnsiConsole Console)
     {
         if (LogLevel >= LogLevel.Error)
         {
-            Console.WriteLine("Error: " + msg);
+            Console.MarkupLineInterpolated($"[red]Error: {msg}[/]");
         }
     }
 
@@ -37,7 +36,7 @@ public sealed record Logger(IAnsiConsole Console)
     {
         if (LogLevel >= LogLevel.Warn)
         {
-            Console.WriteLine("Warning: " + msg);
+            Console.MarkupLineInterpolated($"[yellow]Warning: {msg}[/]");
         }
     }
 

--- a/src/dnvm/RestoreCommand.cs
+++ b/src/dnvm/RestoreCommand.cs
@@ -206,8 +206,7 @@ public static partial class RestoreCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Error("Could not fetch the releases index: ");
-            logger.Error(e.Message);
+            logger.Error($"Could not fetch the releases index: {e.Message}");
             return Error.CouldntFetchReleaseIndex;
         }
 

--- a/src/dnvm/SelectCommand.cs
+++ b/src/dnvm/SelectCommand.cs
@@ -43,7 +43,7 @@ public static class SelectCommand
 
         if (!validDirs.Contains(newDir))
         {
-            logger.Log($"Invalid SDK directory name: {newDir.Name}");
+            logger.Error($"Invalid SDK directory name: {newDir.Name}");
             logger.Log("Valid SDK directory names:");
             foreach (var dir in validDirs)
             {

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -78,7 +78,7 @@ public class SelfInstallCommand
 
         if (!Utilities.IsSingleFile)
         {
-            logger.Log("Cannot self-install into target location: the current executable is not deployed as a single file.");
+            logger.Error("Cannot self-install into target location: the current executable is not deployed as a single file.");
             return Result.SelfInstallFailed;
         }
 
@@ -108,7 +108,7 @@ public class SelfInstallCommand
         var targetPath = DnvmEnv.DnvmExePath;
         if (!opt.Force && env.DnvmHomeFs.FileExists(targetPath))
         {
-            logger.Log("dnvm is already installed at: " + targetPath);
+            logger.Error("dnvm is already installed at: " + targetPath);
             logger.Log("Did you mean to run `dnvm update`? Otherwise, the '--force' flag is required to overwrite the existing file.");
             return Result.SelfInstallFailed;
         }
@@ -187,7 +187,7 @@ public class SelfInstallCommand
         }
         catch (Exception e)
         {
-            _logger.Log($"Could not copy file from '{procPath}' to '{targetPath}': {e.Message}");
+            _logger.Error($"Could not copy file from '{procPath}' to '{targetPath}': {e.Message}");
             return Result.SelfInstallFailed;
         }
 

--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -118,7 +118,7 @@ public class SelfInstallCommand
         {
             Console.WriteLine("Which channel would you like to start tracking?");
             Console.WriteLine("Available channels:");
-            List<Channel> channels = [ new Channel.Latest(), new Channel.Sts(), new Channel.Lts(), new Channel.Preview() ];
+            List<Channel> channels = [new Channel.Latest(), new Channel.Sts(), new Channel.Lts(), new Channel.Preview()];
             for (int i = 0; i < channels.Count; i++)
             {
                 var c = channels[i];
@@ -191,7 +191,8 @@ public class SelfInstallCommand
             return Result.SelfInstallFailed;
         }
 
-        var result = await TrackCommand.Run(_env, _logger, new TrackCommand.Options {
+        var result = await TrackCommand.Run(_env, _logger, new TrackCommand.Options
+        {
             Channel = channel,
             Force = _opts.Force,
             Verbose = _opts.Verbose,
@@ -363,12 +364,10 @@ public class SelfInstallCommand
                 // dotnet.exe is in one of the system path variables. Produce a warning
                 // that the dnvm dotnet.exe will not appear on the path as long as the
                 // system variable is present.
-                logger.Log("");
                 logger.Warn("Found 'dotnet.exe' inside the System PATH environment variable. " +
-                    "System PATH is always preferred over user path on Windows, so the dnvm-installed " +
+                    "System PATH is always preferred over User path on Windows, so the dnvm-installed " +
                     "dotnet.exe will not be accessible until it is removed. " +
                     "It is strongly recommended to remove dotnet from your System PATH now.");
-                logger.Log("");
             }
             logger.Log("Adding install directory to user path: " + dnvmHome);
             WindowsAddToPath(logger, env, dnvmHome);

--- a/src/dnvm/TrackCommand.cs
+++ b/src/dnvm/TrackCommand.cs
@@ -161,8 +161,7 @@ public sealed class TrackCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Error("Could not fetch the releases index: ");
-            logger.Error(e.Message);
+            logger.Error($"Could not fetch the releases index: {e.Message}");
             return Result.CouldntFetchIndex;
         }
 

--- a/src/dnvm/UntrackCommand.cs
+++ b/src/dnvm/UntrackCommand.cs
@@ -26,7 +26,7 @@ public sealed class UntrackCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Log("Failed to read manifest file");
+            logger.Error("Failed to read manifest file");
             return 1;
         }
         var result = RunHelper(channel, manifest, logger);

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -97,8 +97,7 @@ public sealed partial class UpdateCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            _logger.Error("Could not fetch the releases index: ");
-            _logger.Error(e.Message);
+            _logger.Error($"Could not fetch the releases index: {e.Message}");
             return CouldntFetchIndex;
         }
 
@@ -290,8 +289,7 @@ public sealed partial class UpdateCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Error("Could not fetch releases from URL: " + releasesUrl);
-            logger.Error(e.Message);
+            logger.Error($"Could not fetch releases from URL '{releasesUrl}': {e.Message}");
             return (false, null);
         }
 
@@ -388,8 +386,7 @@ public sealed partial class UpdateCommand
             const string usageString = "usage: ";
             if (ps.ExitCode != 0)
             {
-                logger?.Error("Could not run downloaded dnvm:");
-                logger?.Error(error);
+                logger?.Error($"Could not run downloaded dnvm: {error}");
                 return false;
             }
             else if (!output.Contains(usageString))

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -123,7 +123,7 @@ public sealed partial class UpdateCommand
         // Check for dnvm updates
         if (await CheckForSelfUpdates(env.HttpClient, logger, releasesUrl, manifest.PreviewsEnabled) is (true, _))
         {
-            logger.Log("dnvm is out of date. Run 'dnvm update --self' to update dnvm.");
+            logger.Warn("dnvm is out of date. Run 'dnvm update --self' to update dnvm.");
         }
 
         try

--- a/test/UnitTests/RestoreTests.cs
+++ b/test/UnitTests/RestoreTests.cs
@@ -18,7 +18,9 @@ public sealed class RestoreTests
         var restoreResult = await RestoreCommand.Run(env, logger, new DnvmSubCommand.RestoreArgs() { Local = isLocalInstall });
         Assert.Equal(RestoreCommand.Error.NoGlobalJson, restoreResult);
         Assert.Equal("""
+
         Error: No global.json found in the current directory or any of its parents.
+
 
         """.NormalizeLineEndings(), console.Output.TrimLines());
     });

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -72,7 +72,9 @@ public sealed class SelectTests
         Assert.Equal(SelectCommand.Result.BadDirName, result);
 
         Assert.Equal("""
-Invalid SDK directory name: bad
+
+Error: Invalid SDK directory name: bad
+
 Valid SDK directory names:
   dn
 


### PR DESCRIPTION
Add color to warnings and errors in the console to make them more noticeable. I also added a single newline of padding before and after warnings and errors to make them stand out, which was sometimes being done ad-hoc with empty log statements.

Here's an example warning and error:

![image](https://github.com/user-attachments/assets/f3b413ed-63d8-41ae-b689-f4a9ee727fef)

![image](https://github.com/user-attachments/assets/64337396-216d-4e2b-b644-687566fa715c)
