### PR TITLE
Move linux distro version back to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-x64
             zipSuffix: tar.gz
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             rid: linux-arm64
             zipSuffix: tar.gz
           - os: windows-latest
@@ -70,7 +70,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The build machine ends up as a glibc dependency for the built binary. By moving back to 22.04 we'll move the glibc dependency back as well.