### PR TITLE
Fix update tracking for dirs

### DIFF
--- a/src/dnvm/ManifestSchema/Manifest.cs
+++ b/src/dnvm/ManifestSchema/Manifest.cs
@@ -23,7 +23,7 @@ public sealed partial record Manifest
     public EqArray<InstalledSdk> InstalledSdks { get; init; } = [];
     public EqArray<RegisteredChannel> RegisteredChannels { get; init; } = [];
 
-    internal Manifest TrackChannel(RegisteredChannel channel)
+    public Manifest TrackChannel(RegisteredChannel channel)
     {
         var existing = RegisteredChannels.FirstOrNull(c =>
             c.ChannelName == channel.ChannelName && c.SdkDirName == channel.SdkDirName);

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -185,12 +185,15 @@ public sealed partial class UpdateCommand
                     {
                         var latestSdkVersion = SemVersion.Parse(newestAvailable.LatestSdk, SemVersionStyles.Strict);
 
-                        var oldTracked = manifest.RegisteredChannels.Single(t => t.ChannelName == c);
-                        var newTracked = oldTracked with
+
+                        foreach (var oldTracked in manifest.RegisteredChannels.Where(t => t.ChannelName == c))
                         {
-                            InstalledSdkVersions = oldTracked.InstalledSdkVersions.Add(latestSdkVersion)
-                        };
-                        manifest = manifest with { RegisteredChannels = manifest.RegisteredChannels.Replace(oldTracked, newTracked) };
+                            var newTracked = oldTracked with
+                            {
+                                InstalledSdkVersions = oldTracked.InstalledSdkVersions.Add(latestSdkVersion)
+                            };
+                            manifest = manifest with { RegisteredChannels = manifest.RegisteredChannels.Replace(oldTracked, newTracked) };
+                        }
                     }
                 }
             }

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -75,11 +75,17 @@ public sealed class MockServer : IAsyncDisposable
         };
     }
 
+    public void ClearVersions()
+    {
+        ChannelIndexMap.Clear();
+        ReleasesIndexJson = DotnetReleasesIndex.Empty;
+    }
+
     [MemberNotNull(nameof(ReleasesIndexJson))]
     public ChannelReleaseIndex.Release RegisterReleaseVersion(SemVersion version, string releaseType, string supportPhase)
     {
         var majorMinor = version.ToMajorMinor();
-        ReleasesIndexJson ??= new DotnetReleasesIndex{ ChannelIndices = [ ] };
+        ReleasesIndexJson ??= DotnetReleasesIndex.Empty;
         var channel = ReleasesIndexJson.ChannelIndices.SingleOrDefault(c => c.MajorMinorVersion == majorMinor);
         if (channel is null)
         {


### PR DESCRIPTION
The old CLI didn't guard against installing the same SDK into multiple dirs, so it's possible for an update command to see the old dirs in the manifest. This avoids an exception in that case and updates all dirs.