### PR TITLE
Separate writing to the console from logging

### DIFF
--- a/src/dnvm/ListCommand.cs
+++ b/src/dnvm/ListCommand.cs
@@ -11,12 +11,12 @@ public static class ListCommand
 {
     /// <summary>
     /// Prints a list of installed SDK versions and their locations.
-    public static async Task<int> Run(Logger logger, DnvmEnv home)
+    public static async Task<int> Run(Logger logger, DnvmEnv env)
     {
         Manifest manifest;
         try
         {
-            manifest = await home.ReadManifest();
+            manifest = await env.ReadManifest();
         }
         catch (Exception e)
         {
@@ -25,17 +25,17 @@ public static class ListCommand
             return 1;
         }
 
-        PrintSdks(logger, manifest, home.RealPath(UPath.Root));
+        PrintSdks(env.Console, manifest, env.RealPath(UPath.Root));
 
         return 0;
     }
 
-    public static void PrintSdks(Logger logger, Manifest manifest, string homePath)
+    public static void PrintSdks(IAnsiConsole console, Manifest manifest, string homePath)
     {
-        logger.Log($"DNVM_HOME: {homePath}");
-        logger.Log();
-        logger.Log("Installed SDKs:");
-        logger.Log();
+        console.WriteLine($"DNVM_HOME: {homePath}");
+        console.WriteLine();
+        console.WriteLine("Installed SDKs:");
+        console.WriteLine();
         var table = new Table();
         table.AddColumn(new TableColumn(" "));
         table.AddColumn("Version");
@@ -49,14 +49,14 @@ public static class ListCommand
                 .Select(c => c.ChannelName.GetLowerName());
             table.AddRow(selected, sdk.SdkVersion.ToString(), string.Join(", ", channels), sdk.SdkDirName.Name);
         }
-        logger.Console.Write(table);
+        console.Write(table);
 
-        logger.Log();
-        logger.Log("Tracked channels:");
-        logger.Log();
+        console.WriteLine();
+        console.WriteLine("Tracked channels:");
+        console.WriteLine();
         foreach (var c in manifest.TrackedChannels())
         {
-            logger.Log($" • {c.ChannelName.GetLowerName()}");
+            console.WriteLine($" • {c.ChannelName.GetLowerName()}");
         }
     }
 }

--- a/src/dnvm/Logger.cs
+++ b/src/dnvm/Logger.cs
@@ -1,58 +1,24 @@
-using System;
-using Spectre.Console;
+using System.IO;
 
 namespace Dnvm;
 
-public enum LogLevel
+public sealed class Logger(TextWriter console)
 {
-    Error = 1,
-    Warn,
-    Normal,
-    Info,
-}
-
-public sealed record Logger(IAnsiConsole Console)
-{
-    // Mutable for now, should be immutable once the command line parser supports global options
-    public LogLevel LogLevel = LogLevel.Normal;
-
-    public void Error(string msg)
-    {
-        if (LogLevel >= LogLevel.Error)
-        {
-            Console.MarkupLineInterpolated($"{Environment.NewLine}[default on red]Error[/]: {msg}{Environment.NewLine}");
-        }
-    }
-
-    public void Info(string msg)
-    {
-        if (LogLevel >= LogLevel.Info)
-        {
-            Console.WriteLine($"Info({DateTime.UtcNow.TimeOfDay}): {msg}");
-        }
-    }
-
-    public void Warn(string msg)
-    {
-        if (LogLevel >= LogLevel.Warn)
-        {
-            Console.MarkupLineInterpolated($"{Environment.NewLine}[default on yellow]Warning[/]: {msg}{Environment.NewLine}");
-        }
-    }
+    public bool Enabled { get; set; } = false;
 
     public void Log()
     {
-        if (LogLevel >= LogLevel.Normal)
+        if (Enabled)
         {
-            Console.WriteLine();
+            console.WriteLine();
         }
     }
 
-    public void Log(string msg)
+    public void Log(string message)
     {
-        if (LogLevel >= LogLevel.Normal)
+        if (Enabled)
         {
-            Console.WriteLine(msg);
+            console.WriteLine(message);
         }
     }
 }

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Semver;
 using Spectre.Console;
@@ -20,7 +21,7 @@ public static class Program
         }
         console.WriteLine("dnvm " + SemVer + " " + GitVersionInformation.ShortSha);
         console.WriteLine();
-        var logger = new Logger(console);
+        var logger = new Logger(Console.Error);
 
         var parsedArgs = CommandLineArguments.TryParse(console, args);
         if (parsedArgs is null)
@@ -32,7 +33,7 @@ public static class Program
         // Self-install is special, since we don't know the DNVM_HOME yet.
         if (parsedArgs.SubCommand is DnvmSubCommand.SelfInstallArgs selfInstallArgs)
         {
-            return (int)await SelfInstallCommand.Run(logger, selfInstallArgs);
+            return (int)await SelfInstallCommand.Run(logger, console, selfInstallArgs);
         }
 
         using var env = DnvmEnv.CreateDefault();
@@ -69,7 +70,7 @@ public static class Program
             DnvmSubCommand.UpdateArgs a => (int)await UpdateCommand.Run(env, logger, a),
             DnvmSubCommand.ListArgs => (int)await ListCommand.Run(logger, env),
             DnvmSubCommand.SelectArgs a => (int)await SelectCommand.Run(env, logger, new(a.SdkDirName)),
-            DnvmSubCommand.UntrackArgs a => await UntrackCommand.Run(env, logger, a.Channel),
+            DnvmSubCommand.UntrackArgs a => await UntrackCommand.Run(env, a.Channel),
             DnvmSubCommand.UninstallArgs a => await UninstallCommand.Run(env, logger, a.SdkVersion, a.SdkDir),
             DnvmSubCommand.PruneArgs a => await PruneCommand.Run(env, logger, a),
             DnvmSubCommand.RestoreArgs a => await RestoreCommand.Run(env, logger, a) switch {

--- a/src/dnvm/SelectCommand.cs
+++ b/src/dnvm/SelectCommand.cs
@@ -39,15 +39,16 @@ public static class SelectCommand
 
     public static Task<Result<Manifest, Result>> RunWithManifest(DnvmEnv env, SdkDirName newDir, Manifest manifest, Logger logger)
     {
+        var console = env.Console;
         var validDirs = manifest.RegisteredChannels.Select(c => c.SdkDirName).ToList();
 
         if (!validDirs.Contains(newDir))
         {
-            logger.Error($"Invalid SDK directory name: {newDir.Name}");
-            logger.Log("Valid SDK directory names:");
+            console.Error($"Invalid SDK directory name: {newDir.Name}");
+            console.WriteLine("Valid SDK directory names:");
             foreach (var dir in validDirs)
             {
-                logger.Log($"  {dir.Name}");
+                console.WriteLine($"  {dir.Name}");
             }
             return Task.FromResult<Result<Manifest, Result>>(Result.BadDirName);
         }
@@ -99,10 +100,10 @@ public static class SelectCommand
     {
         var dotnetExePath = DnvmEnv.GetSdkPath(sdkDirName) / Utilities.DotnetExeName;
         var realDotnetPath = dnvmEnv.RealPath(dotnetExePath);
-        logger.Info($"Retargeting symlink in {dnvmEnv.RealPath(UPath.Root)} to {realDotnetPath}");
+        logger.Log($"Retargeting symlink in {dnvmEnv.RealPath(UPath.Root)} to {realDotnetPath}");
         if (!dnvmEnv.DnvmHomeFs.FileExists(dotnetExePath))
         {
-            logger.Info("SDK install not found, skipping symlink creation.");
+            logger.Log("SDK install not found, skipping symlink creation.");
             return;
         }
 

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Semver;
+using Spectre.Console;
 using Zio;
 
 namespace Dnvm;
@@ -19,7 +20,7 @@ public sealed class UninstallCommand
         }
         catch (Exception e)
         {
-            logger.Error($"Error reading manifest: {e.Message}");
+            env.Console.Error($"Error reading manifest: {e.Message}");
             throw;
         }
 
@@ -50,7 +51,7 @@ public sealed class UninstallCommand
 
         if (sdksToRemove.Count == 0)
         {
-            logger.Error($"SDK version {sdkVersion} is not installed.");
+            env.Console.Error($"SDK version {sdkVersion} is not installed.");
             return 1;
         }
 
@@ -76,7 +77,7 @@ public sealed class UninstallCommand
             var verString = version.ToString();
             var sdkDir = DnvmEnv.GetSdkPath(dir) / "sdk" / verString;
 
-            logger.Log($"Deleting SDK {verString} from {dir.Name}");
+            env.Console.WriteLine($"Deleting SDK {verString} from {dir.Name}");
 
             env.DnvmHomeFs.DeleteDirectory(sdkDir, isRecursive: true);
         }
@@ -91,7 +92,7 @@ public sealed class UninstallCommand
             var hostfxrDir = DnvmEnv.GetSdkPath(dir) / "host" / "fxr" / verString;
             var packsHostDir = DnvmEnv.GetSdkPath(dir) / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / verString;
 
-            logger.Log($"Deleting Runtime {verString} from {dir.Name}");
+            env.Console.WriteLine($"Deleting Runtime {verString} from {dir.Name}");
 
             env.DnvmHomeFs.DeleteDirectory(netcoreappDir, isRecursive: true);
             env.DnvmHomeFs.DeleteDirectory(hostfxrDir, isRecursive: true);
@@ -107,7 +108,7 @@ public sealed class UninstallCommand
             var aspnetDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.AspNetCore.App" / verString;
             var templatesDir = DnvmEnv.GetSdkPath(dir) / "templates" / verString;
 
-            logger.Log($"Deleting ASP.NET pack {verString} from {dir.Name}");
+            env.Console.WriteLine($"Deleting ASP.NET pack {verString} from {dir.Name}");
 
             env.DnvmHomeFs.DeleteDirectory(aspnetDir, isRecursive: true);
             env.DnvmHomeFs.DeleteDirectory(templatesDir, isRecursive: true);
@@ -123,7 +124,7 @@ public sealed class UninstallCommand
 
             if (env.DnvmHomeFs.DirectoryExists(winDir))
             {
-                logger.Log($"Deleting Windows Desktop pack {verString} from {dir.Name}");
+                env.Console.WriteLine($"Deleting Windows Desktop pack {verString} from {dir.Name}");
 
                 env.DnvmHomeFs.DeleteDirectory(winDir, isRecursive: true);
             }

--- a/src/dnvm/UntrackCommand.cs
+++ b/src/dnvm/UntrackCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Spectre.Console;
 
 namespace Dnvm;
 
@@ -17,7 +18,7 @@ public sealed class UntrackCommand
         public record ManifestReadError : Result;
     }
 
-    public static async Task<int> Run(DnvmEnv env, Logger logger, Channel channel)
+    public static async Task<int> Run(DnvmEnv env, Channel channel)
     {
         Manifest manifest;
         try
@@ -26,10 +27,10 @@ public sealed class UntrackCommand
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.Error("Failed to read manifest file");
+            env.Console.Error("Failed to read manifest file");
             return 1;
         }
-        var result = RunHelper(channel, manifest, logger);
+        var result = RunHelper(channel, manifest, env.Console);
         if (result is Result.Success({} newManifest))
         {
             env.WriteManifest(newManifest);
@@ -38,11 +39,11 @@ public sealed class UntrackCommand
         return 1;
     }
 
-    public static Result RunHelper(Channel channel, Manifest manifest, Logger logger)
+    public static Result RunHelper(Channel channel, Manifest manifest, IAnsiConsole console)
     {
         if (!manifest.TrackedChannels().Any(c => c.ChannelName == channel))
         {
-            logger.Log("Channel '{channel}' is not tracked");
+            console.WriteLine("Channel '{channel}' is not tracked");
             return new Result.ChannelUntracked();
         }
 

--- a/src/dnvm/Utilities/IAnsiConsoleExt.cs
+++ b/src/dnvm/Utilities/IAnsiConsoleExt.cs
@@ -1,0 +1,18 @@
+
+using System;
+using Spectre.Console;
+
+namespace Dnvm;
+
+internal static class IAnsiConsoleExt
+{
+    public static void Error(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"{Environment.NewLine}[default on red]Error[/]: {message}{Environment.NewLine}");
+    }
+
+    public static void Warn(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"{Environment.NewLine}[default on yellow]Warning[/]: {message}{Environment.NewLine}");
+    }
+}

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -44,14 +44,14 @@ public sealed record DirectoryResource(
 public static class SpectreUtil
 {
     public static Task<string?> DownloadWithProgress(
-        this Logger logger,
         ScopedHttpClient client,
+        IAnsiConsole console,
+        Logger logger,
         string filePath,
         string url,
         string description,
         int? bufferSizeParam = null)
     {
-        var console = logger.Console;
         return console.Progress()
             .AutoRefresh(true)
             .Columns(
@@ -76,7 +76,7 @@ public static class SpectreUtil
             // Use 1/100 of the file size as the buffer size, up to 1 MB.
             const int oneMb = 1024 * 1024;
             var bufferSize = bufferSizeParam ?? (int)Math.Min(contentLength / 100, oneMb);
-            logger.Info($"Buffer size: {bufferSize} bytes");
+            logger.Log($"Buffer size: {bufferSize} bytes");
 
             var progressTask = ctx.AddTask(description, maxValue: contentLength);
             console.MarkupLine($"Starting download (size: {contentLength / oneMb:0.00} MB)");

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Spectre.Console.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/UpdateTests.cs
+++ b/test/IntegrationTests/UpdateTests.cs
@@ -1,3 +1,4 @@
+using Spectre.Console.Testing;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,7 +37,6 @@ public sealed class UpdateTests
             new() { ["DNVM_HOME"] = dnvmHome.Path });
         var output = proc.Out;
         var error = proc.Error;
-        Assert.Equal("", error);
         Assert.Contains("Hello from dnvm test", output);
         Assert.Equal(0, proc.ExitCode);
     });
@@ -65,7 +65,6 @@ public sealed class UpdateTests
             new() { ["DNVM_HOME"] = dnvmHome.Path });
         var output = proc.Out;
         var error = proc.Error;
-        Assert.Equal("", error);
         Assert.Contains("dnvm is up-to-date", output, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(0, proc.ExitCode);
 
@@ -83,7 +82,6 @@ public sealed class UpdateTests
             new() { ["DNVM_HOME"] = dnvmHome.Path });
         output = proc.Out;
         error = proc.Error;
-        Assert.Equal("", error);
         Assert.Contains("Hello from dnvm test", output);
         Assert.Equal(0, proc.ExitCode);
     });
@@ -106,7 +104,6 @@ public sealed class UpdateTests
             new() { ["DNVM_HOME"] = dnvmHome.Path });
         var output = result.Out;
         var error = result.Error;
-        Assert.Equal("", error);
         Assert.Equal(0, result.ExitCode);
         result = await ProcUtil.RunWithOutput(dnvmTmpPath, "-h");
         Assert.DoesNotContain("Hello from dnvm test", result.Out);
@@ -118,6 +115,6 @@ public sealed class UpdateTests
     {
         using var tmpDir = TestUtils.CreateTempDirectory();
         var dnvmTmpPath = tmpDir.CopyFile(SelfInstallTests.DnvmExe);
-        Assert.True(await UpdateCommand.ValidateBinary(null, dnvmTmpPath));
+        Assert.True(await UpdateCommand.ValidateBinary(new TestConsole(), logger: null, dnvmTmpPath));
     }
 }

--- a/test/Shared/Dnvm.Test.Shared.csproj
+++ b/test/Shared/Dnvm.Test.Shared.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit.core" />
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="staticcs.async" />
+    <PackageReference Include="Spectre.Console.Testing" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/Shared/TestOptions.cs
+++ b/test/Shared/TestOptions.cs
@@ -1,4 +1,5 @@
 
+using Spectre.Console.Testing;
 using Zio;
 using Zio.FileSystems;
 
@@ -33,6 +34,7 @@ public sealed class TestEnv : IDisposable
                 isPhysical: true,
                 getUserEnvVar: s => _envVars.TryGetValue(s, out var val) ? val : null,
                 setUserEnvVar: (name, val) => _envVars[name] = val,
+                new TestConsole(),
                 [ dotnetFeedUrl ],
                 releasesUrl);
     }

--- a/test/UnitTests/SelectTests.cs
+++ b/test/UnitTests/SelectTests.cs
@@ -7,12 +7,11 @@ namespace Dnvm.Test;
 
 public sealed class SelectTests
 {
-    private readonly TestConsole _console = new();
     private readonly Logger _logger;
 
     public SelectTests(ITestOutputHelper output)
     {
-        _logger = new Logger(_console);
+        _logger = new Logger(new StringWriter());
     }
 
     [Fact]
@@ -78,7 +77,7 @@ Error: Invalid SDK directory name: bad
 Valid SDK directory names:
   dn
 
-""".Replace(Environment.NewLine, "\n"), _console.Output);
+""".Replace(Environment.NewLine, "\n"), ((TestConsole)env.Console).Output);
     });
 
     private static void AssertSdkDir(

--- a/test/UnitTests/TrackTests.cs
+++ b/test/UnitTests/TrackTests.cs
@@ -10,12 +10,12 @@ namespace Dnvm.Test;
 
 public sealed class TrackTests
 {
-    private readonly TestConsole _console = new();
+    private readonly TextWriter _log = new StringWriter();
     private readonly Logger _logger;
 
     public TrackTests()
     {
-        _logger = new Logger(_console);
+        _logger = new Logger(_log);
     }
 
     [Fact]
@@ -190,17 +190,16 @@ public sealed class TrackTests
     [Fact]
     public Task TrackPreviouslyTracked() => RunWithServer(async (mockServer, env) =>
     {
-        var logger = new Logger(new TestConsole());
         var channel = new Channel.Latest();
-        var result = await TrackCommand.Run(env, logger, new TrackCommand.Options
+        var result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = channel,
         });
         Assert.Equal(TrackCommand.Result.Success, result);
 
-        var untrackCode = await UntrackCommand.Run(env, logger, channel);
+        var untrackCode = await UntrackCommand.Run(env, channel);
         Assert.Equal(0, untrackCode);
-        result = await TrackCommand.Run(env, logger, new TrackCommand.Options
+        result = await TrackCommand.Run(env, _logger, new TrackCommand.Options
         {
             Channel = channel,
         });
@@ -225,7 +224,7 @@ public sealed class TrackTests
             Channel = new Channel.Preview()
         });
         Assert.Equal(TrackCommand.Result.Success, result);
-        Assert.Contains("Proceeding without SDK installation", _console.Output);
+        Assert.Contains("Proceeding without SDK installation", ((TestConsole)env.Console).Output);
         var manifest = await env.ReadManifest();
         Assert.Equal([ new RegisteredChannel {
             ChannelName = new Channel.Preview(),

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -10,7 +10,7 @@ namespace Dnvm.Test;
 
 public sealed class UninstallTests
 {
-    private readonly Logger _logger = new Logger(new TestConsole());
+    private readonly Logger _logger = new Logger(new StringWriter());
 
     [Fact]
     public Task LtsAndPreview() => RunWithServer(async (server, env) =>
@@ -73,10 +73,12 @@ public sealed class UninstallTests
         var ltsVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[0].LatestSdk, SemVersionStyles.Strict);
         var previewVersion = SemVersion.Parse(server.ReleasesIndexJson.ChannelIndices[1].LatestSdk, SemVersionStyles.Strict);
 
-        var uninstallConsole = new TestConsole();
-        var unResult = await UninstallCommand.Run(env, new Logger(uninstallConsole), previewVersion);
+        var console = (TestConsole)env.Console;
+        var trimOutput = console.Output;
+        var unResult = await UninstallCommand.Run(env, _logger, previewVersion);
+        var actualOutput = console.Output[trimOutput.Length..];
         Assert.Equal(0, unResult);
-        Assert.DoesNotContain("SdkDirName", uninstallConsole.Output);
-        Assert.DoesNotContain(ltsVersion.ToString(), uninstallConsole.Output);
+        Assert.DoesNotContain("SdkDirName", actualOutput);
+        Assert.DoesNotContain(ltsVersion.ToString(), actualOutput);
     });
 }

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -20,7 +20,7 @@ public sealed class UpdateTests
 
     public UpdateTests()
     {
-        _logger = new Logger(new TestConsole());
+        _logger = new Logger(new StringWriter());
     }
 
     private static Task TestWithServer(Func<MockServer, DnvmEnv, Task> test)
@@ -55,16 +55,14 @@ public sealed class UpdateTests
             ]
         };
         var releasesIndex = mockServer.ReleasesIndexJson;
-        var console = new TestConsole();
-        var logger = new Logger(console);
         _ = await UpdateCommand.UpdateSdks(
             env,
-            logger,
+            _logger,
             releasesIndex,
             manifest,
             yes: false,
             env.DnvmReleasesUrl!);
-        Assert.Contains("dnvm is out of date", console.Output);
+        Assert.Contains("dnvm is out of date", ((TestConsole)env.Console).Output);
     });
 
     [Fact]


### PR DESCRIPTION
dnvm really has two output streams: a user output stream and a diagnostics output stream. This change separates them and puts the diag stream to standard error.