### PR TITLE
Fix restoring previews and daily builds

### DIFF
--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -148,10 +148,11 @@ public sealed partial class DnvmEnv : IDisposable
         return await ManifestUtils.DeserializeNewOrOldManifest(HttpClient, text, DotnetFeedUrls);
     }
 
-    public void WriteManifest(Manifest manifest)
+    public Task WriteManifest(Manifest manifest)
     {
         var text = JsonSerializer.Serialize(manifest);
         DnvmHomeFs.WriteAllText(ManifestPath, text, Encoding.UTF8);
+        return Task.CompletedTask;
     }
 
     public void Dispose()

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -130,7 +130,7 @@ public static partial class InstallCommand
     }
 
 
-    private static async Task<(ChannelReleaseIndex.Component, ChannelReleaseIndex.Release)?> TryGetReleaseFromServer(
+    internal static async Task<(ChannelReleaseIndex.Component, ChannelReleaseIndex.Release)?> TryGetReleaseFromServer(
         DnvmEnv env,
         SemVersion sdkVersion)
     {
@@ -271,7 +271,7 @@ public static partial class InstallCommand
                 })
             };
 
-            env.WriteManifest(manifest);
+            await env.WriteManifest(manifest);
         }
 
         return manifest;

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -57,7 +57,7 @@ public static class Program
     {
         var manifest = await ManifestUtils.ReadOrCreateManifest(env);
         manifest = manifest with { PreviewsEnabled = true };
-        env.WriteManifest(manifest);
+        await env.WriteManifest(manifest);
         return 0;
     }
 

--- a/src/dnvm/SelectCommand.cs
+++ b/src/dnvm/SelectCommand.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,14 +26,13 @@ public static class SelectCommand
         switch (await RunWithManifest(dnvmEnv, sdkDirName, manifest, logger))
         {
             case Result<Manifest, Result>.Ok(var newManifest):
-                dnvmEnv.WriteManifest(newManifest);
+                await dnvmEnv.WriteManifest(newManifest);
                 return Result.Success;
             case Result<Manifest, Result>.Err(var error):
                 return error;
             default:
                 throw ExceptionUtilities.Unreachable;
         }
-        ;
     }
 
     public static Task<Result<Manifest, Result>> RunWithManifest(DnvmEnv env, SdkDirName newDir, Manifest manifest, Logger logger)

--- a/src/dnvm/TrackCommand.cs
+++ b/src/dnvm/TrackCommand.cs
@@ -195,7 +195,7 @@ No builds available for channel '{channel}'. This often happens for preview chan
 preview has not yet been released.
 Proceeding without SDK installation.
 """);
-                dnvmEnv.WriteManifest(manifest);
+                await dnvmEnv.WriteManifest(manifest);
                 return Result.Success;
             }
         }
@@ -254,7 +254,7 @@ Proceeding without SDK installation.
         }
 
         logger.Log("Writing manifest");
-        dnvmEnv.WriteManifest(manifest);
+        await dnvmEnv.WriteManifest(manifest);
 
         console.WriteLine("Successfully installed");
 

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -65,7 +65,7 @@ public sealed class UninstallCommand
         DeleteWins(env, winToRemove, logger);
 
         manifest = UninstallSdk(manifest, sdkVersion);
-        env.WriteManifest(manifest);
+        await env.WriteManifest(manifest);
 
         return 0;
     }

--- a/src/dnvm/UntrackCommand.cs
+++ b/src/dnvm/UntrackCommand.cs
@@ -33,7 +33,7 @@ public sealed class UntrackCommand
         var result = RunHelper(channel, manifest, env.Console);
         if (result is Result.Success({} newManifest))
         {
-            env.WriteManifest(newManifest);
+            await env.WriteManifest(newManifest);
             return 0;
         }
         return 1;

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -203,7 +203,7 @@ public sealed partial class UpdateCommand
         finally
         {
             logger.Log("Writing manifest");
-            env.WriteManifest(manifest);
+            await env.WriteManifest(manifest);
         }
 
         env.Console.WriteLine("Successfully installed");

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -69,7 +69,7 @@ Tracked channels:
             }, new Channel.Latest());
 
         using var testEnv = new TestEnv(DnvmEnv.DefaultDotnetFeedUrls[0], DnvmEnv.DefaultReleasesUrl);
-        testEnv.DnvmEnv.WriteManifest(manifest);
+        await testEnv.DnvmEnv.WriteManifest(manifest);
 
         var ret = await ListCommand.Run(_logger, testEnv.DnvmEnv);
         Assert.Equal(0, ret);
@@ -112,7 +112,7 @@ Tracked channels:
             setUserEnvVar: (name, val) => envVars[name] = val,
             console
         );
-        env.WriteManifest(manifest);
+        await env.WriteManifest(manifest);
 
         var ret = await ListCommand.Run(_logger, env);
         Assert.Equal(0, ret);
@@ -141,7 +141,7 @@ Tracked channels:
         {
             throw new InvalidOperationException();
         }
-        env.WriteManifest(newManifest);
+        await env.WriteManifest(newManifest);
         ret = await ListCommand.Run(_logger, env);
         output = """
 DNVM_HOME: /

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -367,7 +367,7 @@ public sealed class UpdateTests
             ChannelName = new Channel.Lts(),
             SdkDirName = new("custom-sdk-dir"),
         });
-        env.WriteManifest(manifest);
+        await env.WriteManifest(manifest);
         var updatedVersion = new SemVersion(6, 0, 1);
         mockServer.RegisterReleaseVersion(updatedVersion, "lts", "active");
 


### PR DESCRIPTION
There were two underlying bugs. The first was that `restore` wasn't properly doing version comparisons for preview builds. The second was that it didn't check the feed URL directly in the case that the index was missing the build. Since daily builds are never in the index, this meant you couldn't restore a daily build.

This PR fixes both issues and adds regression tests.