### PR TITLE
Allow installing an sdk to a target path

### DIFF
--- a/src/dnvm/CommandLineArguments.cs
+++ b/src/dnvm/CommandLineArguments.cs
@@ -45,6 +45,9 @@ public abstract partial record DnvmSubCommand
 
         [CommandOption("-v|--verbose", Description = "Print debugging messages to the console.")]
         public bool? Verbose { get; init; } = null;
+
+        [CommandOption("-d|--directory", Description = "Install the SDK into the target directory instead of the DNVM_HOME directory.")]
+        public string? Dir { get; init; } = null;
     }
 
     [Command("track", Summary = "Start tracking a new channel.")]

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -152,6 +152,11 @@ public static class Utilities
     [UnsupportedOSPlatform("windows")]
     public static void ChmodExec(IFileSystem vfs, UPath upath)
     {
+        if (vfs is MemoryFileSystem)
+        {
+            // We only end up here in tests, so we can skip chmod
+            return;
+        }
         var realPath = vfs.ConvertPathToInternal(upath);
         var mod = File.GetUnixFileMode(realPath);
         File.SetUnixFileMode(realPath, mod | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);

--- a/test/UnitTests/CommandLineTests.cs
+++ b/test/UnitTests/CommandLineTests.cs
@@ -259,7 +259,7 @@ Options:
             [ "install", param ]));
         Assert.Equal("""
 usage: dnvm install [-f | --force] [-s | --sdk-dir <sdkDir>] [-v | --verbose]
-[-h | --help] <version>
+[-d | --directory <dir>] [-h | --help] <version>
 
 Install an SDK.
 
@@ -271,6 +271,8 @@ Options:
     -s, --sdk-dir  <sdkDir>  Install the SDK into a separate directory with the
 given name.
     -v, --verbose  Print debugging messages to the console.
+    -d, --directory  <dir>  Install the SDK into the target directory instead of
+the DNVM_HOME directory.
     -h, --help  Show help information.
 
 


### PR DESCRIPTION
Adds a command line arg '-d | --directory' to dotnet install.