### PR TITLE
Make manifest migrations easier

### DIFF
--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -150,7 +150,7 @@ public sealed partial class DnvmEnv : IDisposable
 
     public Task WriteManifest(Manifest manifest)
     {
-        var text = JsonSerializer.Serialize(manifest);
+        var text = JsonSerializer.Serialize(manifest.ToManifestV8());
         DnvmHomeFs.WriteAllText(ManifestPath, text, Encoding.UTF8);
         return Task.CompletedTask;
     }

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -319,7 +319,7 @@ public static partial class InstallCommand
 
         SelectCommand.SelectDir(logger, env, manifest.CurrentSdkDir, sdkDir);
 
-        var result = JsonSerializer.Serialize(manifest);
+        var result = JsonSerializer.Serialize(manifest.ToManifestV8());
         logger.Log("Existing manifest: " + result);
 
         if (!ManifestUtils.IsSdkInstalled(manifest, sdkVersion, sdkDir))

--- a/src/dnvm/ManifestSchema/ManifestV8.cs
+++ b/src/dnvm/ManifestSchema/ManifestV8.cs
@@ -1,0 +1,95 @@
+
+using System;
+using System.Linq;
+using Semver;
+using Serde;
+using StaticCs.Collections;
+
+namespace Dnvm;
+
+/// <summary>
+/// Serializes the <see cref="SdkDirName.Name"/> directly as a string.
+/// </summary>
+internal sealed class SdkDirNameV8 : ISerde<SdkDirName>, ISerdeProvider<SdkDirNameV8, SdkDirNameV8, SdkDirName>
+{
+    public static SdkDirNameV8 Instance { get; } = new();
+    public ISerdeInfo SerdeInfo => StringProxy.SerdeInfo;
+
+    public SdkDirName Deserialize(IDeserializer deserializer)
+        => new SdkDirName(StringProxy.Instance.Deserialize(deserializer));
+
+    public void Serialize(SdkDirName value, ISerializer serializer)
+    {
+        serializer.WriteString(value.Name);
+    }
+}
+
+[GenerateSerde]
+public sealed partial record ManifestV8(
+    bool PreviewsEnabled,
+    SdkDirName CurrentSdkDir,
+    EqArray<InstalledSdkV8> InstalledSdks,
+    EqArray<RegisteredChannelV8> RegisteredChannels
+)
+{
+    // Serde doesn't serialize consts, so we have a separate property below for serialization.
+    public const int VersionField = 8;
+
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public int Version => VersionField;
+}
+
+[GenerateSerde]
+public partial record RegisteredChannelV8
+{
+    public required Channel ChannelName { get; init; }
+    public required SdkDirName SdkDirName { get; init; }
+    [SerdeMemberOptions(
+        SerializeProxy = typeof(EqArrayProxy.Ser<SemVersion, SemVersionProxy>),
+        DeserializeProxy = typeof(EqArrayProxy.De<SemVersion, SemVersionProxy>))]
+    public EqArray<SemVersion> InstalledSdkVersions { get; init; } = EqArray<SemVersion>.Empty;
+    public bool Untracked { get; init; } = false;
+}
+
+[GenerateSerde]
+public partial record InstalledSdkV8
+{
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion ReleaseVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion SdkVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion RuntimeVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion AspNetVersion { get; init; }
+
+    public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
+}
+
+public static partial class ManifestV8Convert
+{
+    public static ManifestV8 Convert(this ManifestV7 v7) => new ManifestV8
+    (
+        PreviewsEnabled: false,
+        CurrentSdkDir: v7.CurrentSdkDir,
+        InstalledSdks: v7.InstalledSdks.SelectAsArray(v => v.Convert()),
+        RegisteredChannels: v7.RegisteredChannels.SelectAsArray(c => c.Convert())
+    );
+
+    public static InstalledSdkV8 Convert(this InstalledSdkV7 v7) => new InstalledSdkV8
+    {
+        ReleaseVersion = v7.ReleaseVersion,
+        SdkVersion = v7.SdkVersion,
+        RuntimeVersion = v7.RuntimeVersion,
+        AspNetVersion = v7.AspNetVersion,
+        SdkDirName = v7.SdkDirName,
+    };
+
+    public static RegisteredChannelV8 Convert(this RegisteredChannelV7 v7) => new RegisteredChannelV8
+    {
+        ChannelName = v7.ChannelName,
+        SdkDirName = v7.SdkDirName,
+        InstalledSdkVersions = v7.InstalledSdkVersions,
+        Untracked = v7.Untracked,
+    };
+}

--- a/src/dnvm/ManifestUtils.cs
+++ b/src/dnvm/ManifestUtils.cs
@@ -132,10 +132,10 @@ public static partial class ManifestUtils
         var version = JsonSerializer.Deserialize<ManifestVersionOnly>(manifestSrc).Version;
         // Handle versions that don't need the release index to convert
         Manifest? manifest = version switch {
-            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert().Convert(),
-            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert().Convert(),
-            ManifestV7.VersionField => JsonSerializer.Deserialize<ManifestV7>(manifestSrc).Convert(),
-            Manifest.VersionField => JsonSerializer.Deserialize<Manifest>(manifestSrc),
+            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert().Convert().Convert(),
+            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert().Convert().Convert(),
+            ManifestV7.VersionField => JsonSerializer.Deserialize<ManifestV7>(manifestSrc).Convert().Convert(),
+            ManifestV8.VersionField => JsonSerializer.Deserialize<ManifestV8>(manifestSrc).Convert(),
             _ => null
         };
         if (manifest is not null)
@@ -149,13 +149,13 @@ public static partial class ManifestUtils
         {
             // The first version didn't have a version field
             null => (await JsonSerializer.Deserialize<ManifestV1>(manifestSrc)
-                .Convert().Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+                .Convert().Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert(),
             ManifestV2.VersionField => (await JsonSerializer.Deserialize<ManifestV2>(manifestSrc)
-                .Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+                .Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert(),
             ManifestV3.VersionField => (await JsonSerializer.Deserialize<ManifestV3>(manifestSrc)
-                .Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+                .Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert(),
             ManifestV4.VersionField => (await JsonSerializer.Deserialize<ManifestV4>(manifestSrc)
-                .Convert(httpClient, releasesIndex)).Convert().Convert().Convert(),
+                .Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert(),
             _ => throw new InvalidDataException("Unknown manifest version: " + version)
         };
     }


### PR DESCRIPTION
Disables auto (de)serialization of the manifest directly and requires explicit conversion to a specific schema version.