### PR TITLE
Move install config to an env variable

### DIFF
--- a/src/dnvm/DnvmEnv.cs
+++ b/src/dnvm/DnvmEnv.cs
@@ -132,7 +132,8 @@ public sealed partial class DnvmEnv
         Directory.CreateDirectory(realPath);
 
         return new DnvmEnv(
-            userHome: GetFolderPath(SpecialFolder.UserProfile, SpecialFolderOption.DoNotVerify),
+            userHome: Environment.GetEnvironmentVariable("HOME")
+                ?? GetFolderPath(SpecialFolder.UserProfile, SpecialFolderOption.DoNotVerify),
             new SubFileSystem(PhysicalFs, PhysicalFs.ConvertPathFromInternal(realPath)),
             PhysicalFs,
             PhysicalFs.ConvertPathFromInternal(Environment.CurrentDirectory),

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -274,7 +274,7 @@ public sealed partial class UpdateCommand
 
         await DownloadToTempAndDelete(
             downloads,
-            downloadDir => HandleDownload(downloadDir, tempArchiveDir, archiveName)
+            downloadDir => VerifyAndExtract(downloadDir, tempArchiveDir, archiveName)
         );
         _logger.Log($"{tempArchiveDir} contents: {string.Join(", ", Directory.GetFiles(tempArchiveDir))}");
 
@@ -292,7 +292,7 @@ public sealed partial class UpdateCommand
     /// Unpack the downloaded archive to the given temp directory. The archive is expected to
     /// have the name <param name="archiveName"/> and be located in the <param name="downloadDir"/>.
     /// </summary>
-    private async Task HandleDownload(string downloadDir, string tempArchiveDir, string archiveName)
+    private async Task VerifyAndExtract(string downloadDir, string tempArchiveDir, string archiveName)
     {
         var relkeyPath = Path.Combine(downloadDir, ReleaseKeyFileName);
         var relkeySigPath = Path.Combine(downloadDir, ReleaseKeySigFileName);

--- a/test/IntegrationTests/Runner.cs
+++ b/test/IntegrationTests/Runner.cs
@@ -1,0 +1,57 @@
+
+using Zio;
+
+namespace Dnvm.Test;
+
+internal static class DnvmRunner
+{
+    public static async Task<ProcUtil.ProcResult> RunAndRestoreEnv(
+        DnvmEnv env,
+        string dnvmPath,
+        string dnvmArgs,
+        Action? envChecker = null)
+    {
+        var savedVars = new Dictionary<string, string?>();
+        const string PATH = "PATH";
+        const string DOTNET_ROOT = "DOTNET_ROOT";
+        const string DNVM_HOME = "DNVM_HOME";
+        if (OperatingSystem.IsWindows())
+        {
+            SaveVars(savedVars);
+        }
+        try
+        {
+            var procResult = await ProcUtil.RunWithOutput(
+                dnvmPath,
+                dnvmArgs,
+                new()
+                {
+                    ["HOME"] = env.UserHome,
+                    ["DNVM_HOME"] = env.RealPath(UPath.Root)
+                }
+            );
+            // Allow the test to check the environment variables before they are restored
+            envChecker?.Invoke();
+            return procResult;
+        }
+        finally
+        {
+            RestoreVars(savedVars);
+        }
+
+        static void SaveVars(Dictionary<string, string?> savedVars)
+        {
+            savedVars[PATH] = Environment.GetEnvironmentVariable(PATH, EnvironmentVariableTarget.User);
+            savedVars[DOTNET_ROOT] = Environment.GetEnvironmentVariable(DOTNET_ROOT, EnvironmentVariableTarget.User);
+            savedVars[DNVM_HOME] = Environment.GetEnvironmentVariable(DNVM_HOME, EnvironmentVariableTarget.User);
+        }
+
+        static void RestoreVars(Dictionary<string, string?> savedVars)
+        {
+            foreach (var kvp in savedVars)
+            {
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value, EnvironmentVariableTarget.User);
+            }
+        }
+    }
+}

--- a/test/Shared/TestOptions.cs
+++ b/test/Shared/TestOptions.cs
@@ -22,13 +22,13 @@ public sealed class TestEnv : IDisposable
         var cwd = cwdOpt ?? UPath.Root;
 
         var physicalFs = DnvmEnv.PhysicalFs;
-        var homeFs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_dnvmHome.Path));
+        var dnvmFs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_dnvmHome.Path));
         var cwdFs = new SubFileSystem(physicalFs, physicalFs.ConvertPathFromInternal(_workingDir.Path));
         cwdFs.CreateDirectory(cwd);
 
         DnvmEnv = new DnvmEnv(
                 userHome: _userHome.Path,
-                homeFs,
+                dnvmFs,
                 cwdFs,
                 cwd,
                 isPhysical: true,


### PR DESCRIPTION
Rather than prompting the user for an output path, use the DNVM_HOME env variable to decide the install path. This is a relatively uncommon scneario and requiring an env variable indicates how it will also be used in the future: via setting the DNVM_HOME variable for all shells.