### PR TITLE
Update shell files with no content

### DIFF
--- a/src/dnvm/SelfInstallCommand.cs
+++ b/src/dnvm/SelfInstallCommand.cs
@@ -488,18 +488,13 @@ public class SelfInstallCommand
         console.WriteLine("PATH updated.");
     }
 
-    private static ImmutableArray<string> ProfileShellFiles => ImmutableArray.Create<string>(
-        ".profile",
-        ".bashrc",
-        ".zshrc"
-    );
+    private static ImmutableArray<string> ProfileShellFiles => [".profile", ".bashrc", ".zshrc" ];
 
 
     private static async Task<bool> FileContainsLine(string filePath, string contents)
     {
-        using var file = MemoryMappedFile.CreateFromFile(filePath, FileMode.Open);
-        var stream = file.CreateViewStream();
-        using var reader = new StreamReader(stream);
+        using var file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var reader = new StreamReader(file);
         string? line;
         while ((line = await reader.ReadLineAsync()) is not null)
         {

--- a/test/Shared/ConditionalTheory.cs
+++ b/test/Shared/ConditionalTheory.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Dnvm.Test;
+
+public class ConditionalTheoryAttribute : TheoryAttribute
+{
+    public ConditionalTheoryAttribute(params Type[] conditions)
+    {
+        foreach (var condType in conditions)
+        {
+            var cond = (ExecutionCondition)Activator.CreateInstance(condType)!;
+            if (cond.ShouldSkip)
+            {
+                base.Skip = cond.SkipReason;
+            }
+        }
+    }
+}


### PR DESCRIPTION
A bug caused empty shell files to not be updated when doing a self-install.

Fixes https://github.com/dn-vm/dnvm/issues/223