### PR TITLE
Default dotnet encoding is broken

### DIFF
--- a/src/dnvm/Encoding.cs
+++ b/src/dnvm/Encoding.cs
@@ -1,0 +1,10 @@
+
+namespace Dnvm;
+
+internal static class Encoding
+{
+    /// <summary>
+    /// UTF-8 encoding without the BOM and with strict error handling.
+    /// </summary>
+    public static readonly System.Text.Encoding UTF8 = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+}

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Semver;
 using Serde;

--- a/src/dnvm/Program.cs
+++ b/src/dnvm/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Semver;
 using Spectre.Console;

--- a/src/dnvm/UpdateCommand.cs
+++ b/src/dnvm/UpdateCommand.cs
@@ -1,15 +1,10 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Dnvm.Signing;
 using Semver;

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -1,9 +1,5 @@
-
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Reflection.Metadata.Ecma335;
-using System.Security.Cryptography;
 using System.Text;
 using Dnvm.Signing;
 using Semver;


### PR DESCRIPTION
Uses BOM, doesn't throw on invalid