### PR TITLE
Suggest a 3 digit SDK patch version when a 1 or 2 digit patch is requested

### DIFF
--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -62,8 +62,7 @@ public static partial class InstallCommand
         if (result is not Result.Success && args.SdkVersion.Patch < 100)
         {
             env.Console.Error($"Requested SDK version '{args.SdkVersion}' with patch '{args.SdkVersion.Patch}'. " +
-            "The dotnet SDK typically has 3 digit patches versions. " +
-            $"Did you mean '{args.SdkVersion.WithSuggestedThreeDigitPatch()}'?");
+            "The dotnet SDK typically has 3 digit patches versions.");
         }
         return result;
     }

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -36,7 +36,7 @@ public static partial class InstallCommand
         public (UPath Dir, IFileSystem DirFs)? TargetDir { get; init; } = null;
     }
 
-    public static Task<Result> Run(DnvmEnv env, Logger logger, DnvmSubCommand.InstallArgs args)
+    public static async Task<Result> Run(DnvmEnv env, Logger logger, DnvmSubCommand.InstallArgs args)
     {
         (UPath Dir, IFileSystem DirFs)? targetDir = null;
         if (args.Dir is not null)
@@ -50,7 +50,7 @@ public static partial class InstallCommand
             targetDir = (dirPath, env.CwdFs);
         }
 
-        return Run(env, logger, new Options
+        Result result = await Run(env, logger, new Options
         {
             SdkVersion = args.SdkVersion,
             Force = args.Force ?? false,
@@ -58,6 +58,14 @@ public static partial class InstallCommand
             Verbose = args.Verbose ?? false,
             TargetDir = targetDir,
         });
+
+        if (result is not Result.Success && args.SdkVersion.Patch < 100)
+        {
+            env.Console.Error($"Requested SDK version '{args.SdkVersion}' with patch '{args.SdkVersion.Patch}'. " +
+            "The dotnet SDK typically has 3 digit patches versions. " +
+            $"Did you mean '{args.SdkVersion.WithSuggestedThreeDigitPatch()}'?");
+        }
+        return result;
     }
 
     public static async Task<Result> Run(DnvmEnv env, Logger logger, Options options)
@@ -282,7 +290,7 @@ public static partial class InstallCommand
         public partial record Component
         {
             [SerdeMemberOptions(DeserializeProxy = typeof(SemVersionProxy))]
-            public required SemVersion Version { get; init;  }
+            public required SemVersion Version { get; init; }
         }
     }
 

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -62,7 +62,7 @@ public static partial class InstallCommand
         if (result is not Result.Success && args.SdkVersion.Patch < 100)
         {
             env.Console.Error($"Requested SDK version '{args.SdkVersion}' with patch '{args.SdkVersion.Patch}'. " +
-            "The dotnet SDK typically has 3 digit patches versions.");
+            "The dotnet SDK typically has 3 digit patch versions. Is this a runtime version?");
         }
         return result;
     }

--- a/src/dnvm/Utilities/Extensions.cs
+++ b/src/dnvm/Utilities/Extensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Immutable;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Semver;
 
 namespace Dnvm;
 
@@ -56,4 +57,16 @@ internal static class ImmutableArrayExt2
         }
         return result;
     }
+}
+
+internal static class SemVerExtensions
+{
+    public static SemVersion WithSuggestedThreeDigitPatch(this SemVersion version) =>
+        version.Patch switch
+        {
+            >= 100 => throw new InvalidOperationException("Patch version is already three digits"),
+            0 => version.WithPatch(100),
+            < 10 => version.WithPatch(version.Patch * 100),
+            < 100 and >= 10 => version.WithPatch(version.Patch * 10)
+        };
 }

--- a/src/dnvm/Utilities/Extensions.cs
+++ b/src/dnvm/Utilities/Extensions.cs
@@ -58,15 +58,3 @@ internal static class ImmutableArrayExt2
         return result;
     }
 }
-
-internal static class SemVerExtensions
-{
-    public static SemVersion WithSuggestedThreeDigitPatch(this SemVersion version) =>
-        version.Patch switch
-        {
-            >= 100 => throw new InvalidOperationException("Patch version is already three digits"),
-            0 => version.WithPatch(100),
-            < 10 => version.WithPatch(version.Patch * 100),
-            < 100 and >= 10 => version.WithPatch(version.Patch * 10)
-        };
-}

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -464,7 +464,6 @@ public sealed class InstallTests
         Assert.Equal(InstallCommand.Result.UnknownChannel, result); // Should fail lookup
         var output = console.Output;
         Assert.Contains($"Requested SDK version '{version}'", output);
-        Assert.Contains($"Did you mean '{suggested}'?", output);
     });
 
     [Theory]
@@ -481,7 +480,6 @@ public sealed class InstallTests
         Assert.Equal(InstallCommand.Result.UnknownChannel, result);
         var output = console.Output;
         Assert.DoesNotContain("Requested SDK version", output);
-        Assert.DoesNotContain("Did you mean", output);
     });
 
     static SemVersion SemVersion(string version) => Semver.SemVersion.Parse(version, SemVersionStyles.Strict);


### PR DESCRIPTION
I've spent an embarrassing amount of time trying to figure out why dnvm can't find an sdk version, only to find out I've been pasting the runtime version (1 patch digit) rather than the sdk version (3 patch digits) I really wanted. A suggestion here would save me (and hopefully others) a bit of time staring at version numbers.