### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,6 @@
     <GitHeadSha Condition="'$(RefPath)' != '' AND Exists('$(RefPath)')">$([System.IO.File]::ReadAllText('$(RefPath)').Trim())</GitHeadSha>
     <GitHeadSha Condition="'$(HeadFileContent)' != '' AND '$(RefPath)' == ''">$(HeadFileContent)</GitHeadSha>
     <ShortSha Condition="'$(GitHeadSha)' != ''">$(GitHeadSha.Substring(0, 8))</ShortSha>
-    <SemVer>1.1.1</SemVer>
+    <SemVer>1.1.2</SemVer>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Bump version to 1.1.2 for the next release.

## Changes since v1.1.1

### Bug Fixes
* Fix SDK extraction failing on tarballs with symlinks (.NET 11 Preview 2+) #326

### Dependencies
* Bump Azure.Security.KeyVault.Keys from 4.8.0 to 4.9.0
* Bump coverlet.collector from 6.0.4 to 8.0.0
* Bump xunit.v3 from 3.2.1 to 3.2.2
* Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.3.0
* Bump Serde from 0.10.0 to 0.10.2