### PR TITLE
Clean up SDK packs and manifests on uninstall

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -13,7 +13,14 @@ dnvm uninstall <version> [--dir <directory>]
 
 ## How It Works
 
-The uninstall command removes the SDK and checks which runtime components (runtimes, ASP.NET, templates, etc.) are still needed by other installed SDKs. Only components that are no longer needed are removed.
+The uninstall command removes the SDK and checks which shared components are still needed by other installed SDKs. Only components that are no longer needed are removed. This includes:
+
+- Shared frameworks (`Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`, `Microsoft.WindowsDesktop.App`)
+- Reference and host packs under `packs/` (`Microsoft.NETCore.App.Ref`, `Microsoft.AspNetCore.App.Ref`, `Microsoft.NETCore.App.Host.<rid>`, `Microsoft.WindowsDesktop.App.Ref`)
+- Host `fxr`, templates, and the SDK itself
+- Workload manifests under `sdk-manifests/<feature-band>` (removed only when no other installed SDK contributed that directory and no workload installation metadata references it). A single SDK archive can lay down manifests under several feature bands, so dnvm records the set of directories each install contributed. SDKs installed by dnvm versions older than this feature have no recorded set, and their presence disables `sdk-manifests` cleanup for that SDK directory entirely.
+
+Workload packs installed via `dotnet workload install` (for example the iOS, Android, and MacCatalyst packs) are not tracked by dnvm and are not removed. Use `dotnet workload clean` to reclaim that space.
 
 ## Examples
 

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -353,6 +353,7 @@ public static partial class InstallCommand
             AspNetVersion = release.AspNetCore.Version,
             WindowsDesktopVersion = release.WindowsDesktop.Version,
             SdkManifestBands = sdkManifestBands.OrderBy(band => band, StringComparer.Ordinal).ToEq(),
+            SdkManifestBandsKnown = true,
             SdkVersion = sdkVersion,
             SdkDirName = sdkDir,
         };

--- a/src/dnvm/InstallCommand.cs
+++ b/src/dnvm/InstallCommand.cs
@@ -10,6 +10,7 @@ using Serde;
 using Serde.Json;
 using Spectre.Console;
 using StaticCs;
+using StaticCs.Collections;
 using Zio;
 using Zio.FileSystems;
 
@@ -323,6 +324,7 @@ public static partial class InstallCommand
 
         env.Console.WriteLine($"Downloading SDK {sdkVersion} for {ridString}");
         var curMuxerVersion = manifest.MuxerVersion(sdkDir);
+        var sdkManifestBands = new HashSet<string>(StringComparer.Ordinal);
         var err = await InstallSdkToDir(
             curMuxerVersion,
             release.Runtime.Version,
@@ -332,7 +334,8 @@ public static partial class InstallCommand
             env.DnvmHomeFs,
             sdkInstallPath,
             env.TempFs,
-            logger);
+            logger,
+            sdkManifestBands);
         if (err is not null)
         {
             return err;
@@ -343,22 +346,27 @@ public static partial class InstallCommand
         var result = JsonSerializer.Serialize(manifest.ConvertToLatest());
         logger.Log("Existing manifest: " + result);
 
-        if (!manifest.IsSdkInstalled(sdkVersion, sdkDir))
+        var installedSdk = new InstalledSdk
         {
-            manifest = manifest with
-            {
-                InstalledSdks = manifest.InstalledSdks.Add(new InstalledSdk
-                {
-                    ReleaseVersion = release.ReleaseVersion,
-                    RuntimeVersion = release.Runtime.Version,
-                    AspNetVersion = release.AspNetCore.Version,
-                    SdkVersion = sdkVersion,
-                    SdkDirName = sdkDir,
-                })
-            };
+            ReleaseVersion = release.ReleaseVersion,
+            RuntimeVersion = release.Runtime.Version,
+            AspNetVersion = release.AspNetCore.Version,
+            WindowsDesktopVersion = release.WindowsDesktop.Version,
+            SdkManifestBands = sdkManifestBands.OrderBy(band => band, StringComparer.Ordinal).ToEq(),
+            SdkVersion = sdkVersion,
+            SdkDirName = sdkDir,
+        };
 
-            await @lock.WriteManifest(env, manifest);
-        }
+        var existingSdk = manifest.InstalledSdks.FirstOrDefault(
+            sdk => sdk.SdkVersion == sdkVersion && sdk.SdkDirName == sdkDir);
+        manifest = manifest with
+        {
+            InstalledSdks = existingSdk is null
+                ? manifest.InstalledSdks.Add(installedSdk)
+                : manifest.InstalledSdks.Replace(existingSdk, installedSdk)
+        };
+
+        await @lock.WriteManifest(env, manifest);
 
         return manifest;
     }
@@ -372,7 +380,8 @@ public static partial class InstallCommand
         IFileSystem destFs,
         UPath destPath,
         IFileSystem tempFs,
-        Logger logger)
+        Logger logger,
+        ISet<string>? sdkManifestBands = null)
     {
         // The Release name does not contain a version
         string archiveName = ConstructArchiveName(versionString: null, Utilities.CurrentRID, Utilities.ZipSuffix);
@@ -403,7 +412,8 @@ public static partial class InstallCommand
             archivePath,
             tempFs,
             destFs,
-            destPath);
+            destPath,
+            sdkManifestBands);
         File.Delete(archivePath);
         if (extractResult != null)
         {

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -40,10 +40,11 @@ public partial record InstalledSdk
     /// A single archive can lay down in-box workload manifests under multiple feature bands
     /// (mobile/MAUI manifests routinely lag the SDK's own band), so the SDK's own feature band
     /// is not sufficient to determine which manifest directories it contributed.
-    /// An empty array means "unknown" (the SDK predates this field) and suppresses all
-    /// <c>sdk-manifests</c> cleanup in that SDK directory.
+    /// <see cref="SdkManifestBandsKnown"/> distinguishes a known-empty archive from a legacy
+    /// SDK whose manifest-band ownership could not be determined.
     /// </summary>
     public EqArray<string> SdkManifestBands { get; init; } = EqArray<string>.Empty;
+    public bool SdkManifestBandsKnown { get; init; } = false;
 
     public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
 }
@@ -102,6 +103,7 @@ partial record Manifest
             WindowsDesktopVersion = semVersion,
             ReleaseVersion = semVersion,
             SdkManifestBands = EqArray.Create(semVersion.ToFeatureBand()),
+            SdkManifestBandsKnown = true,
         };
         return AddSdk(installedSdk, c);
     }

--- a/src/dnvm/Manifest.cs
+++ b/src/dnvm/Manifest.cs
@@ -33,6 +33,17 @@ public partial record InstalledSdk
     public required SemVersion SdkVersion { get; init; }
     public required SemVersion RuntimeVersion { get; init; }
     public required SemVersion AspNetVersion { get; init; }
+    public required SemVersion? WindowsDesktopVersion { get; init; }
+
+    /// <summary>
+    /// The <c>sdk-manifests/&lt;feature-band&gt;</c> directories contained in this SDK's archive.
+    /// A single archive can lay down in-box workload manifests under multiple feature bands
+    /// (mobile/MAUI manifests routinely lag the SDK's own band), so the SDK's own feature band
+    /// is not sufficient to determine which manifest directories it contributed.
+    /// An empty array means "unknown" (the SDK predates this field) and suppresses all
+    /// <c>sdk-manifests</c> cleanup in that SDK directory.
+    /// </summary>
+    public EqArray<string> SdkManifestBands { get; init; } = EqArray<string>.Empty;
 
     public SdkDirName SdkDirName { get; init; } = DnvmEnv.DefaultSdkDirName;
 }
@@ -88,7 +99,9 @@ partial record Manifest
             SdkVersion = semVersion,
             RuntimeVersion = semVersion,
             AspNetVersion = semVersion,
+            WindowsDesktopVersion = semVersion,
             ReleaseVersion = semVersion,
+            SdkManifestBands = EqArray.Create(semVersion.ToFeatureBand()),
         };
         return AddSdk(installedSdk, c);
     }
@@ -322,4 +335,3 @@ internal static class ManifestLockingConfig
     /// </summary>
     public static TimeSpan BaseRetryDelay { get; set; } = TimeSpan.FromMilliseconds(50);
 }
-

--- a/src/dnvm/ManifestSchema/ManifestSerialize.cs
+++ b/src/dnvm/ManifestSchema/ManifestSerialize.cs
@@ -18,8 +18,8 @@ public static partial class ManifestSerialize
     public static string Serialize(Manifest manifest)
     {
         // Convert to the latest version before serializing
-        var manifestV9 = manifest.ConvertToLatest();
-        return JsonSerializer.Serialize(manifestV9);
+        var manifestV10 = manifest.ConvertToLatest();
+        return JsonSerializer.Serialize(manifestV10);
     }
 
     /// <summary>
@@ -35,11 +35,12 @@ public static partial class ManifestSerialize
         // Handle versions that don't need the release index to convert
         Manifest? manifest = version switch
         {
-            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert().Convert().Convert().Convert(),
-            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert().Convert().Convert().Convert(),
-            ManifestV7.VersionField => JsonSerializer.Deserialize<ManifestV7>(manifestSrc).Convert().Convert().Convert(),
-            ManifestV8.VersionField => JsonSerializer.Deserialize<ManifestV8>(manifestSrc).Convert().Convert(),
-            ManifestV9.VersionField => JsonSerializer.Deserialize<ManifestV9>(manifestSrc).Convert(),
+            ManifestV5.VersionField => JsonSerializer.Deserialize<ManifestV5>(manifestSrc).Convert().Convert().Convert().Convert().Convert().Convert(),
+            ManifestV6.VersionField => JsonSerializer.Deserialize<ManifestV6>(manifestSrc).Convert().Convert().Convert().Convert().Convert(),
+            ManifestV7.VersionField => JsonSerializer.Deserialize<ManifestV7>(manifestSrc).Convert().Convert().Convert().Convert(),
+            ManifestV8.VersionField => JsonSerializer.Deserialize<ManifestV8>(manifestSrc).Convert().Convert().Convert(),
+            ManifestV9.VersionField => JsonSerializer.Deserialize<ManifestV9>(manifestSrc).Convert().Convert(),
+            ManifestV10.VersionField => JsonSerializer.Deserialize<ManifestV10>(manifestSrc).Convert(),
             _ => null
         };
         if (manifest is not null)
@@ -54,11 +55,11 @@ public static partial class ManifestSerialize
             // The first version didn't have a version field
             null => throw new InvalidDataException("Manifest is invalid: missing version field"),
             ManifestV2.VersionField => (await JsonSerializer.Deserialize<ManifestV2>(manifestSrc)
-                .Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert(),
+                .Convert().Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert().Convert(),
             ManifestV3.VersionField => (await JsonSerializer.Deserialize<ManifestV3>(manifestSrc)
-                .Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert(),
+                .Convert().Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert().Convert(),
             ManifestV4.VersionField => (await JsonSerializer.Deserialize<ManifestV4>(manifestSrc)
-                .Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert(),
+                .Convert(httpClient, releasesIndex)).Convert().Convert().Convert().Convert().Convert().Convert(),
             _ => throw new InvalidDataException("Unknown manifest version: " + version)
         };
     }
@@ -66,21 +67,23 @@ public static partial class ManifestSerialize
 
 public static class ManifestConvert
 {
-    public static Manifest Convert(this ManifestV9 manifestV9)
+    public static Manifest Convert(this ManifestV10 manifestV10)
     {
         return new Manifest
         {
-            PreviewsEnabled = manifestV9.PreviewsEnabled,
-            CurrentSdkDir = manifestV9.CurrentSdkDir.Convert(),
-            InstalledSdks = manifestV9.InstalledSdks.SelectAsArray(sdk => new InstalledSdk
+            PreviewsEnabled = manifestV10.PreviewsEnabled,
+            CurrentSdkDir = manifestV10.CurrentSdkDir.Convert(),
+            InstalledSdks = manifestV10.InstalledSdks.SelectAsArray(sdk => new InstalledSdk
             {
                 ReleaseVersion = sdk.ReleaseVersion,
                 SdkVersion = sdk.SdkVersion,
                 RuntimeVersion = sdk.RuntimeVersion,
                 AspNetVersion = sdk.AspNetVersion,
+                WindowsDesktopVersion = sdk.WindowsDesktopVersion,
+                SdkManifestBands = sdk.SdkManifestBands,
                 SdkDirName = sdk.SdkDirName.Convert()
             }),
-            RegisteredChannels = manifestV9.RegisteredChannels.SelectAsArray(channel => new RegisteredChannel
+            RegisteredChannels = manifestV10.RegisteredChannels.SelectAsArray(channel => new RegisteredChannel
             {
                 ChannelName = channel.ChannelName,
                 SdkDirName = channel.SdkDirName.Convert(),
@@ -90,21 +93,23 @@ public static class ManifestConvert
         };
     }
 
-    internal static ManifestV9 ConvertToLatest(this Manifest @this)
+    internal static ManifestV10 ConvertToLatest(this Manifest @this)
     {
-        return new ManifestV9
+        return new ManifestV10
         {
             PreviewsEnabled = @this.PreviewsEnabled,
             CurrentSdkDir = @this.CurrentSdkDir.ConvertToLatest(),
-            InstalledSdks = @this.InstalledSdks.SelectAsArray(sdk => new InstalledSdkV9
+            InstalledSdks = @this.InstalledSdks.SelectAsArray(sdk => new InstalledSdkV10
             {
                 ReleaseVersion = sdk.ReleaseVersion,
                 SdkVersion = sdk.SdkVersion,
                 RuntimeVersion = sdk.RuntimeVersion,
                 AspNetVersion = sdk.AspNetVersion,
+                WindowsDesktopVersion = sdk.WindowsDesktopVersion,
+                SdkManifestBands = sdk.SdkManifestBands,
                 SdkDirName = sdk.SdkDirName.ConvertToLatest()
             }),
-            RegisteredChannels = @this.RegisteredChannels.SelectAsArray(channel => new RegisteredChannelV9
+            RegisteredChannels = @this.RegisteredChannels.SelectAsArray(channel => new RegisteredChannelV10
             {
                 ChannelName = channel.ChannelName,
                 SdkDirName = channel.SdkDirName.ConvertToLatest(),
@@ -117,12 +122,12 @@ public static class ManifestConvert
 
 public static class SdkDirNameConvert
 {
-    public static SdkDirName Convert(this SdkDirNameV9 sdkDirNameV9)
+    public static SdkDirName Convert(this SdkDirNameV10 sdkDirNameV10)
     {
-        return new SdkDirName(sdkDirNameV9.Name);
+        return new SdkDirName(sdkDirNameV10.Name);
     }
-    public static SdkDirNameV9 ConvertToLatest(this SdkDirName sdkDirName)
+    public static SdkDirNameV10 ConvertToLatest(this SdkDirName sdkDirName)
     {
-        return new SdkDirNameV9(sdkDirName.Name);
+        return new SdkDirNameV10(sdkDirName.Name);
     }
 }

--- a/src/dnvm/ManifestSchema/ManifestSerialize.cs
+++ b/src/dnvm/ManifestSchema/ManifestSerialize.cs
@@ -81,6 +81,7 @@ public static class ManifestConvert
                 AspNetVersion = sdk.AspNetVersion,
                 WindowsDesktopVersion = sdk.WindowsDesktopVersion,
                 SdkManifestBands = sdk.SdkManifestBands,
+                SdkManifestBandsKnown = sdk.SdkManifestBandsKnown,
                 SdkDirName = sdk.SdkDirName.Convert()
             }),
             RegisteredChannels = manifestV10.RegisteredChannels.SelectAsArray(channel => new RegisteredChannel
@@ -107,6 +108,7 @@ public static class ManifestConvert
                 AspNetVersion = sdk.AspNetVersion,
                 WindowsDesktopVersion = sdk.WindowsDesktopVersion,
                 SdkManifestBands = sdk.SdkManifestBands,
+                SdkManifestBandsKnown = sdk.SdkManifestBandsKnown,
                 SdkDirName = sdk.SdkDirName.ConvertToLatest()
             }),
             RegisteredChannels = @this.RegisteredChannels.SelectAsArray(channel => new RegisteredChannelV10

--- a/src/dnvm/ManifestSchema/ManifestV10.cs
+++ b/src/dnvm/ManifestSchema/ManifestV10.cs
@@ -65,6 +65,7 @@ public partial record InstalledSdkV10
         DeserializeProxy = typeof(NullableRefProxy.De<SemVersion, SemVersionProxy>))]
     public required SemVersion? WindowsDesktopVersion { get; init; }
     public EqArray<string> SdkManifestBands { get; init; } = EqArray<string>.Empty;
+    public bool SdkManifestBandsKnown { get; init; } = false;
     public required SdkDirNameV10 SdkDirName { get; init; }
 }
 
@@ -85,6 +86,7 @@ public static partial class ManifestV10Convert
         RuntimeVersion = v9.RuntimeVersion,
         AspNetVersion = v9.AspNetVersion,
         WindowsDesktopVersion = null,
+        SdkManifestBandsKnown = false,
         SdkDirName = v9.SdkDirName,
     };
 

--- a/src/dnvm/ManifestSchema/ManifestV10.cs
+++ b/src/dnvm/ManifestSchema/ManifestV10.cs
@@ -31,27 +31,22 @@ public sealed partial record ManifestV10
 }
 
 [GenerateSerde]
+[UseProxy(ForType = typeof(SemVersion), Proxy = typeof(SemVersionProxy))]
 public partial record RegisteredChannelV10
 {
     public required Channel ChannelName { get; init; }
     public required SdkDirNameV10 SdkDirName { get; init; }
-    [SerdeMemberOptions(
-        SerializeProxy = typeof(EqArrayProxy.Ser<SemVersion, SemVersionProxy>),
-        DeserializeProxy = typeof(EqArrayProxy.De<SemVersion, SemVersionProxy>))]
     public EqArray<SemVersion> InstalledSdkVersions { get; init; } = EqArray<SemVersion>.Empty;
     public bool Untracked { get; init; } = false;
 }
 
 [GenerateSerde]
+[UseProxy(ForType = typeof(SemVersion), Proxy = typeof(SemVersionProxy))]
 public partial record InstalledSdkV10
 {
-    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
     public required SemVersion ReleaseVersion { get; init; }
-    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
     public required SemVersion SdkVersion { get; init; }
-    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
     public required SemVersion RuntimeVersion { get; init; }
-    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
     public required SemVersion AspNetVersion { get; init; }
     [SerdeMemberOptions(
         SerializeProxy = typeof(NullableRefProxy.Ser<SemVersion, SemVersionProxy>),

--- a/src/dnvm/ManifestSchema/ManifestV10.cs
+++ b/src/dnvm/ManifestSchema/ManifestV10.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using Semver;
+using Serde;
+using StaticCs.Collections;
+
+namespace Dnvm;
+
+[GenerateSerde(With = typeof(SdkDirNameV10._SerdeObj))]
+public sealed partial record SdkDirNameV10(string Name)
+{
+    public string Name { get; init; } = Name.ToLower();
+
+    private sealed class _SerdeObj : ISerde<SdkDirNameV10>
+    {
+        public ISerdeInfo SerdeInfo => StringProxy.SerdeInfo;
+        public SdkDirNameV10 Deserialize(IDeserializer deserializer)
+            => new(StringProxy.Instance.Deserialize(deserializer));
+        public void Serialize(SdkDirNameV10 value, ISerializer serializer)
+            => serializer.WriteString(value.Name);
+    }
+
+    public static implicit operator SdkDirNameV10(SdkDirNameV9 dirName) => new(dirName.Name);
+}
+
+[GenerateSerde]
+public sealed partial record ManifestV10
+{
+    public const int VersionField = 10;
+
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public int Version => VersionField;
+
+    public required bool PreviewsEnabled { get; init; }
+    public required SdkDirNameV10 CurrentSdkDir { get; init; }
+    public required EqArray<InstalledSdkV10> InstalledSdks { get; init; }
+    public required EqArray<RegisteredChannelV10> RegisteredChannels { get; init; }
+}
+
+[GenerateSerde]
+public partial record RegisteredChannelV10
+{
+    public required Channel ChannelName { get; init; }
+    public required SdkDirNameV10 SdkDirName { get; init; }
+    [SerdeMemberOptions(
+        SerializeProxy = typeof(EqArrayProxy.Ser<SemVersion, SemVersionProxy>),
+        DeserializeProxy = typeof(EqArrayProxy.De<SemVersion, SemVersionProxy>))]
+    public EqArray<SemVersion> InstalledSdkVersions { get; init; } = EqArray<SemVersion>.Empty;
+    public bool Untracked { get; init; } = false;
+}
+
+[GenerateSerde]
+public partial record InstalledSdkV10
+{
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion ReleaseVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion SdkVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion RuntimeVersion { get; init; }
+    [SerdeMemberOptions(Proxy = typeof(SemVersionProxy))]
+    public required SemVersion AspNetVersion { get; init; }
+    [SerdeMemberOptions(
+        SerializeProxy = typeof(NullableRefProxy.Ser<SemVersion, SemVersionProxy>),
+        DeserializeProxy = typeof(NullableRefProxy.De<SemVersion, SemVersionProxy>))]
+    public required SemVersion? WindowsDesktopVersion { get; init; }
+    public EqArray<string> SdkManifestBands { get; init; } = EqArray<string>.Empty;
+    public required SdkDirNameV10 SdkDirName { get; init; }
+}
+
+public static partial class ManifestV10Convert
+{
+    public static ManifestV10 Convert(this ManifestV9 v9) => new()
+    {
+        PreviewsEnabled = v9.PreviewsEnabled,
+        CurrentSdkDir = v9.CurrentSdkDir,
+        InstalledSdks = v9.InstalledSdks.SelectAsArray(v => v.Convert()),
+        RegisteredChannels = v9.RegisteredChannels.SelectAsArray(c => c.Convert())
+    };
+
+    public static InstalledSdkV10 Convert(this InstalledSdkV9 v9) => new()
+    {
+        ReleaseVersion = v9.ReleaseVersion,
+        SdkVersion = v9.SdkVersion,
+        RuntimeVersion = v9.RuntimeVersion,
+        AspNetVersion = v9.AspNetVersion,
+        WindowsDesktopVersion = null,
+        SdkDirName = v9.SdkDirName,
+    };
+
+    public static RegisteredChannelV10 Convert(this RegisteredChannelV9 v9) => new()
+    {
+        ChannelName = v9.ChannelName,
+        SdkDirName = v9.SdkDirName,
+        InstalledSdkVersions = v9.InstalledSdkVersions,
+        Untracked = v9.Untracked,
+    };
+}

--- a/src/dnvm/ManifestSchema/ManifestV10.cs
+++ b/src/dnvm/ManifestSchema/ManifestV10.cs
@@ -6,20 +6,13 @@ using StaticCs.Collections;
 
 namespace Dnvm;
 
-[GenerateSerde(With = typeof(SdkDirNameV10._SerdeObj))]
+[GenerateSerde(As = typeof(string))]
 public sealed partial record SdkDirNameV10(string Name)
 {
     public string Name { get; init; } = Name.ToLower();
 
-    private sealed class _SerdeObj : ISerde<SdkDirNameV10>
-    {
-        public ISerdeInfo SerdeInfo => StringProxy.SerdeInfo;
-        public SdkDirNameV10 Deserialize(IDeserializer deserializer)
-            => new(StringProxy.Instance.Deserialize(deserializer));
-        public void Serialize(SdkDirNameV10 value, ISerializer serializer)
-            => serializer.WriteString(value.Name);
-    }
-
+    public static implicit operator string(SdkDirNameV10 dirName) => dirName.Name;
+    public static implicit operator SdkDirNameV10(string name) => new(name);
     public static implicit operator SdkDirNameV10(SdkDirNameV9 dirName) => new(dirName.Name);
 }
 

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -69,7 +69,7 @@ public sealed class UninstallCommand
                     winDirsWithUnknownVersion.Add(installed.SdkDirName);
                 }
                 bandsToKeep.UnionWith(installed.SdkManifestBands.Select(b => (b, installed.SdkDirName)));
-                if (installed.SdkManifestBands.Length == 0)
+                if (!installed.SdkManifestBandsKnown)
                 {
                     bandDirsWithUnknownManifests.Add(installed.SdkDirName);
                 }
@@ -119,17 +119,26 @@ public sealed class UninstallCommand
         foreach (var (version, dir) in runtimes)
         {
             var verString = version.ToString();
-            var netcoreappDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.NETCore.App" / verString;
-            var hostfxrDir = DnvmEnv.GetSdkPath(dir) / "host" / "fxr" / verString;
-            var packsHostDir = DnvmEnv.GetSdkPath(dir) / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / verString;
-            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.NETCore.App.Ref" / verString;
+            var sdkPath = DnvmEnv.GetSdkPath(dir);
+            var hostPackId = $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}";
+            const string refPackId = "Microsoft.NETCore.App.Ref";
+            var netcoreappDir = sdkPath / "shared" / "Microsoft.NETCore.App" / verString;
+            var hostfxrDir = sdkPath / "host" / "fxr" / verString;
+            var packsHostDir = sdkPath / "packs" / hostPackId / verString;
+            var packsRefDir = sdkPath / "packs" / refPackId / verString;
 
             env.Console.WriteLine($"Deleting Runtime {verString} from {dir.Name}");
 
             TryDeleteDirectory(env, netcoreappDir);
             TryDeleteDirectory(env, hostfxrDir);
-            TryDeleteDirectory(env, packsHostDir);
-            TryDeleteDirectory(env, packsRefDir);
+            if (!IsPackReferencedByWorkloads(env, sdkPath, hostPackId, version))
+            {
+                TryDeleteDirectory(env, packsHostDir);
+            }
+            if (!IsPackReferencedByWorkloads(env, sdkPath, refPackId, version))
+            {
+                TryDeleteDirectory(env, packsRefDir);
+            }
         }
     }
 
@@ -138,15 +147,20 @@ public sealed class UninstallCommand
         foreach (var (version, dir) in aspnets)
         {
             var verString = version.ToString();
-            var aspnetDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.AspNetCore.App" / verString;
-            var templatesDir = DnvmEnv.GetSdkPath(dir) / "templates" / verString;
-            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.AspNetCore.App.Ref" / verString;
+            var sdkPath = DnvmEnv.GetSdkPath(dir);
+            const string refPackId = "Microsoft.AspNetCore.App.Ref";
+            var aspnetDir = sdkPath / "shared" / "Microsoft.AspNetCore.App" / verString;
+            var templatesDir = sdkPath / "templates" / verString;
+            var packsRefDir = sdkPath / "packs" / refPackId / verString;
 
             env.Console.WriteLine($"Deleting ASP.NET pack {verString} from {dir.Name}");
 
             TryDeleteDirectory(env, aspnetDir);
             TryDeleteDirectory(env, templatesDir);
-            TryDeleteDirectory(env, packsRefDir);
+            if (!IsPackReferencedByWorkloads(env, sdkPath, refPackId, version))
+            {
+                TryDeleteDirectory(env, packsRefDir);
+            }
         }
     }
 
@@ -155,8 +169,10 @@ public sealed class UninstallCommand
         foreach (var (version, dir) in wins)
         {
             var verString = version.ToString();
-            var winDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.WindowsDesktop.App" / verString;
-            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.WindowsDesktop.App.Ref" / verString;
+            var sdkPath = DnvmEnv.GetSdkPath(dir);
+            const string refPackId = "Microsoft.WindowsDesktop.App.Ref";
+            var winDir = sdkPath / "shared" / "Microsoft.WindowsDesktop.App" / verString;
+            var packsRefDir = sdkPath / "packs" / refPackId / verString;
 
             if (env.DnvmHomeFs.DirectoryExists(winDir))
             {
@@ -164,7 +180,8 @@ public sealed class UninstallCommand
                 TryDeleteDirectory(env, winDir);
             }
 
-            if (env.DnvmHomeFs.DirectoryExists(packsRefDir))
+            if (env.DnvmHomeFs.DirectoryExists(packsRefDir)
+                && !IsPackReferencedByWorkloads(env, sdkPath, refPackId, version))
             {
                 TryDeleteDirectory(env, packsRefDir);
             }
@@ -198,6 +215,17 @@ public sealed class UninstallCommand
         return env.DnvmHomeFs
             .EnumerateFiles(workloadsMetadataDir, "*", SearchOption.AllDirectories)
             .Any(file => file.FullName.Split('/').Contains(band, StringComparer.Ordinal));
+    }
+
+    private static bool IsPackReferencedByWorkloads(
+        DnvmEnv env,
+        UPath sdkPath,
+        string packId,
+        SemVersion version)
+    {
+        var installedPackVersionDir = sdkPath / "metadata" / "workloads" / "InstalledPacks"
+            / "v1" / packId / version.ToString();
+        return env.DnvmHomeFs.DirectoryExists(installedPackVersionDir);
     }
 
     private static Manifest UninstallSdks(

--- a/src/dnvm/UninstallCommand.cs
+++ b/src/dnvm/UninstallCommand.cs
@@ -38,6 +38,10 @@ public sealed class UninstallCommand
         var aspnetToRemove = new HashSet<(SemVersion, SdkDirName)>();
         var winToKeep = new HashSet<(SemVersion, SdkDirName)>();
         var winToRemove = new HashSet<(SemVersion, SdkDirName)>();
+        var winDirsWithUnknownVersion = new HashSet<SdkDirName>();
+        var bandsToKeep = new HashSet<(string, SdkDirName)>();
+        var bandsToRemove = new HashSet<(string, SdkDirName)>();
+        var bandDirsWithUnknownManifests = new HashSet<SdkDirName>();
 
         foreach (var installed in manifest.InstalledSdks)
         {
@@ -46,13 +50,29 @@ public sealed class UninstallCommand
                 sdksToRemove.Add((installed.SdkVersion, installed.SdkDirName));
                 runtimesToRemove.Add((installed.RuntimeVersion, installed.SdkDirName));
                 aspnetToRemove.Add((installed.AspNetVersion, installed.SdkDirName));
-                winToRemove.Add((installed.ReleaseVersion, installed.SdkDirName));
+                if (installed.WindowsDesktopVersion is { } windowsDesktopVersion)
+                {
+                    winToRemove.Add((windowsDesktopVersion, installed.SdkDirName));
+                }
+                bandsToRemove.UnionWith(installed.SdkManifestBands.Select(b => (b, installed.SdkDirName)));
             }
             else
             {
                 runtimesToKeep.Add((installed.RuntimeVersion, installed.SdkDirName));
                 aspnetToKeep.Add((installed.AspNetVersion, installed.SdkDirName));
-                winToKeep.Add((installed.ReleaseVersion, installed.SdkDirName));
+                if (installed.WindowsDesktopVersion is { } windowsDesktopVersion)
+                {
+                    winToKeep.Add((windowsDesktopVersion, installed.SdkDirName));
+                }
+                else
+                {
+                    winDirsWithUnknownVersion.Add(installed.SdkDirName);
+                }
+                bandsToKeep.UnionWith(installed.SdkManifestBands.Select(b => (b, installed.SdkDirName)));
+                if (installed.SdkManifestBands.Length == 0)
+                {
+                    bandDirsWithUnknownManifests.Add(installed.SdkDirName);
+                }
             }
         }
 
@@ -65,13 +85,17 @@ public sealed class UninstallCommand
         runtimesToRemove.ExceptWith(runtimesToKeep);
         aspnetToRemove.ExceptWith(aspnetToKeep);
         winToRemove.ExceptWith(winToKeep);
+        winToRemove.RemoveWhere(win => winDirsWithUnknownVersion.Contains(win.Item2));
+        bandsToRemove.ExceptWith(bandsToKeep);
+        bandsToRemove.RemoveWhere(band => bandDirsWithUnknownManifests.Contains(band.Item2));
 
         DeleteSdks(env, sdksToRemove, logger);
         DeleteRuntimes(env, runtimesToRemove, logger);
         DeleteAspnets(env, aspnetToRemove, logger);
         DeleteWins(env, winToRemove, logger);
+        DeleteSdkManifests(env, bandsToRemove, logger);
 
-        manifest = UninstallSdk(manifest, sdkVersion);
+        manifest = UninstallSdks(manifest, sdksToRemove);
         await @lock.WriteManifest(env, manifest);
 
         return 0;
@@ -98,12 +122,14 @@ public sealed class UninstallCommand
             var netcoreappDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.NETCore.App" / verString;
             var hostfxrDir = DnvmEnv.GetSdkPath(dir) / "host" / "fxr" / verString;
             var packsHostDir = DnvmEnv.GetSdkPath(dir) / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / verString;
+            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.NETCore.App.Ref" / verString;
 
             env.Console.WriteLine($"Deleting Runtime {verString} from {dir.Name}");
 
             TryDeleteDirectory(env, netcoreappDir);
             TryDeleteDirectory(env, hostfxrDir);
             TryDeleteDirectory(env, packsHostDir);
+            TryDeleteDirectory(env, packsRefDir);
         }
     }
 
@@ -114,11 +140,13 @@ public sealed class UninstallCommand
             var verString = version.ToString();
             var aspnetDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.AspNetCore.App" / verString;
             var templatesDir = DnvmEnv.GetSdkPath(dir) / "templates" / verString;
+            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.AspNetCore.App.Ref" / verString;
 
             env.Console.WriteLine($"Deleting ASP.NET pack {verString} from {dir.Name}");
 
             TryDeleteDirectory(env, aspnetDir);
             TryDeleteDirectory(env, templatesDir);
+            TryDeleteDirectory(env, packsRefDir);
         }
     }
 
@@ -128,27 +156,62 @@ public sealed class UninstallCommand
         {
             var verString = version.ToString();
             var winDir = DnvmEnv.GetSdkPath(dir) / "shared" / "Microsoft.WindowsDesktop.App" / verString;
+            var packsRefDir = DnvmEnv.GetSdkPath(dir) / "packs" / "Microsoft.WindowsDesktop.App.Ref" / verString;
 
             if (env.DnvmHomeFs.DirectoryExists(winDir))
             {
                 env.Console.WriteLine($"Deleting Windows Desktop pack {verString} from {dir.Name}");
                 TryDeleteDirectory(env, winDir);
             }
+
+            if (env.DnvmHomeFs.DirectoryExists(packsRefDir))
+            {
+                TryDeleteDirectory(env, packsRefDir);
+            }
         }
     }
 
-    private static Manifest UninstallSdk(Manifest manifest, SemVersion sdkVersion)
+    private static void DeleteSdkManifests(DnvmEnv env, IEnumerable<(string, SdkDirName)> bands, Logger logger)
     {
-        // Delete SDK version from all directories
+        foreach (var (band, dir) in bands)
+        {
+            var sdkPath = DnvmEnv.GetSdkPath(dir);
+            var manifestsDir = sdkPath / "sdk-manifests" / band;
+
+            if (env.DnvmHomeFs.DirectoryExists(manifestsDir)
+                && !IsFeatureBandReferencedByWorkloads(env, sdkPath, band))
+            {
+                env.Console.WriteLine($"Deleting workload manifests for feature band {band} from {dir.Name}");
+                TryDeleteDirectory(env, manifestsDir);
+            }
+        }
+    }
+
+    private static bool IsFeatureBandReferencedByWorkloads(DnvmEnv env, UPath sdkPath, string band)
+    {
+        var workloadsMetadataDir = sdkPath / "metadata" / "workloads";
+        if (!env.DnvmHomeFs.DirectoryExists(workloadsMetadataDir))
+        {
+            return false;
+        }
+
+        return env.DnvmHomeFs
+            .EnumerateFiles(workloadsMetadataDir, "*", SearchOption.AllDirectories)
+            .Any(file => file.FullName.Split('/').Contains(band, StringComparer.Ordinal));
+    }
+
+    private static Manifest UninstallSdks(
+        Manifest manifest,
+        HashSet<(SemVersion Version, SdkDirName Dir)> sdksToRemove)
+    {
         var newVersions = manifest.InstalledSdks
-            .Where(sdk => sdk.SdkVersion != sdkVersion)
+            .Where(sdk => !sdksToRemove.Contains((sdk.SdkVersion, sdk.SdkDirName)))
             .ToEq();
 
-        // Also remove the SDK version from RegisteredChannels.InstalledSdkVersions
         var updatedChannels = manifest.RegisteredChannels.Select(channel =>
         {
             var updatedInstalledVersions = channel.InstalledSdkVersions
-                .Where(version => version != sdkVersion)
+                .Where(version => !sdksToRemove.Contains((version, channel.SdkDirName)))
                 .ToEq();
             return channel with { InstalledSdkVersions = updatedInstalledVersions };
         }).ToEq();

--- a/src/dnvm/Utilities/Utilities.cs
+++ b/src/dnvm/Utilities/Utilities.cs
@@ -175,6 +175,36 @@ public static class Utilities
         return $"{version.Major}.{version.Minor}.{feature}xx";
     }
 
+    /// <summary>
+    /// The SDK feature band directory name, as used under the 'sdk-manifests' directory,
+    /// e.g. "10.0.300" or "11.0.100-preview.6". Build metadata identifiers (such as the
+    /// build number appended to a preview version) are not part of the band.
+    /// </summary>
+    public static string ToFeatureBand(this SemVersion version)
+    {
+        var band = $"{version.Major}.{version.Minor}.{version.Patch / 100 * 100}";
+        var prerelease = version.Prerelease;
+        if (version.Major < 7
+            || string.IsNullOrEmpty(prerelease)
+            || prerelease.Contains("dev", StringComparison.Ordinal)
+            || prerelease.Contains("ci", StringComparison.Ordinal)
+            || prerelease.Contains("rtm", StringComparison.Ordinal))
+        {
+            return band;
+        }
+
+        var prereleaseIdentifiers = version.PrereleaseIdentifiers;
+        if (prereleaseIdentifiers.Count >= 2)
+        {
+            band += $"-{prereleaseIdentifiers[0]}.{prereleaseIdentifiers[1]}";
+        }
+        else
+        {
+            band += $"-{prereleaseIdentifiers[0]}";
+        }
+        return band;
+    }
+
     public static string SeqToString<T>(this IEnumerable<T> e)
     {
         return "[ " + string.Join(", ", e) + " ]";
@@ -279,7 +309,8 @@ public static class Utilities
         string archivePath,
         IFileSystem tempFs,
         IFileSystem destFs,
-        UPath destDir)
+        UPath destDir,
+        ISet<string>? sdkManifestBands = null)
     {
         destFs.CreateDirectory(destDir);
         var tempExtractDir = UPath.Root / Path.GetRandomFileName();
@@ -311,6 +342,19 @@ public static class Utilities
 
         try
         {
+            if (sdkManifestBands is not null)
+            {
+                sdkManifestBands.Clear();
+                var manifestsDir = tempExtractDir / "sdk-manifests";
+                if (tempFs.DirectoryExists(manifestsDir))
+                {
+                    foreach (var manifestBandDir in tempFs.EnumerateDirectories(manifestsDir))
+                    {
+                        sdkManifestBands.Add(manifestBandDir.GetName());
+                    }
+                }
+            }
+
             // We want to copy over all the files from the extraction directory to the target
             // directory, with one exception: the top-level files. Those have special logic.
             CopyTopLevelFiles(existingMuxerVersion, runtimeVersion, tempFs, tempExtractDir, destFs, destDir);

--- a/test/Shared/Assets.cs
+++ b/test/Shared/Assets.cs
@@ -17,7 +17,7 @@ public sealed class Assets
     public const string ArchiveToken = "2c192c853403aa1725f8f99bbe72fe691226fa28";
 
     private static readonly ConcurrentDictionary<
-        (SemVersion Sdk, SemVersion Runtime, SemVersion AspNet, SemVersion WindowsDesktop, string ExtraBands),
+        (SemVersion Sdk, SemVersion Runtime, SemVersion AspNet, SemVersion WindowsDesktop, string ExtraBands, bool IncludeSdkBand),
         byte[]> _archiveCache = new();
 
     public static Stream GetSdkArchive(
@@ -25,10 +25,17 @@ public sealed class Assets
         SemVersion runtimeVersion,
         SemVersion aspnetVersion,
         SemVersion windowsDesktopVersion,
-        IEnumerable<string>? extraManifestBands = null)
+        IEnumerable<string>? extraManifestBands = null,
+        bool includeSdkManifestBand = true)
     {
         var extraBands = (extraManifestBands ?? []).ToList();
-        var versions = (sdkVersion, runtimeVersion, aspnetVersion, windowsDesktopVersion, string.Join(';', extraBands));
+        var versions = (
+            sdkVersion,
+            runtimeVersion,
+            aspnetVersion,
+            windowsDesktopVersion,
+            string.Join(';', extraBands),
+            includeSdkManifestBand);
         if (_archiveCache.TryGetValue(versions, out var archive))
         {
             return new MemoryStream(archive);
@@ -51,7 +58,10 @@ public sealed class Assets
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", "Microsoft.AspNetCore.App.Ref", aspnetVersion.ToString()));
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "shared", "Microsoft.WindowsDesktop.App", windowsDesktopVersion.ToString()));
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", "Microsoft.WindowsDesktop.App.Ref", windowsDesktopVersion.ToString()));
-        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "sdk-manifests", sdkVersion.ToFeatureBand(), "Microsoft.NET.Sdk.SomeWorkload"));
+        if (includeSdkManifestBand)
+        {
+            _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "sdk-manifests", sdkVersion.ToFeatureBand(), "Microsoft.NET.Sdk.SomeWorkload"));
+        }
         // Real SDK archives can also lay down in-box workload manifests under *older* feature
         // bands (the mobile/MAUI manifests routinely lag the SDK's own band), which means two
         // SDKs with different feature bands can share a manifest directory.

--- a/test/Shared/Assets.cs
+++ b/test/Shared/Assets.cs
@@ -16,14 +16,20 @@ public sealed class Assets
     /// </summary>
     public const string ArchiveToken = "2c192c853403aa1725f8f99bbe72fe691226fa28";
 
-    private static readonly ConcurrentDictionary<SemVersion, byte[]> _archiveCache = new();
+    private static readonly ConcurrentDictionary<
+        (SemVersion Sdk, SemVersion Runtime, SemVersion AspNet, SemVersion WindowsDesktop, string ExtraBands),
+        byte[]> _archiveCache = new();
 
     public static Stream GetSdkArchive(
         SemVersion sdkVersion,
         SemVersion runtimeVersion,
-        SemVersion aspnetVersion)
+        SemVersion aspnetVersion,
+        SemVersion windowsDesktopVersion,
+        IEnumerable<string>? extraManifestBands = null)
     {
-        if (_archiveCache.TryGetValue(runtimeVersion, out var archive))
+        var extraBands = (extraManifestBands ?? []).ToList();
+        var versions = (sdkVersion, runtimeVersion, aspnetVersion, windowsDesktopVersion, string.Join(';', extraBands));
+        if (_archiveCache.TryGetValue(versions, out var archive))
         {
             return new MemoryStream(archive);
         }
@@ -40,14 +46,26 @@ public sealed class Assets
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "shared", "Microsoft.NETCore.App", runtimeVersion.ToString()));
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "host", "fxr", runtimeVersion.ToString()));
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}", runtimeVersion.ToString()));
+        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", "Microsoft.NETCore.App.Ref", runtimeVersion.ToString()));
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "shared", "Microsoft.AspNetCore.App", aspnetVersion.ToString()));
+        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", "Microsoft.AspNetCore.App.Ref", aspnetVersion.ToString()));
+        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "shared", "Microsoft.WindowsDesktop.App", windowsDesktopVersion.ToString()));
+        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "packs", "Microsoft.WindowsDesktop.App.Ref", windowsDesktopVersion.ToString()));
+        _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "sdk-manifests", sdkVersion.ToFeatureBand(), "Microsoft.NET.Sdk.SomeWorkload"));
+        // Real SDK archives can also lay down in-box workload manifests under *older* feature
+        // bands (the mobile/MAUI manifests routinely lag the SDK's own band), which means two
+        // SDKs with different feature bands can share a manifest directory.
+        foreach (var extraBand in extraBands)
+        {
+            _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "sdk-manifests", extraBand, "Microsoft.NET.Sdk.SomeMobileWorkload"));
+        }
         _ = Directory.CreateDirectory(Path.Combine(tempDir.Path, "templates", aspnetVersion.ToString()));
 
         using var zipDir = TestUtils.CreateTempDirectory();
         var archivePath = MakeZipOrTarball(tempDir.Path, Path.Combine(zipDir.Path, "dotnet"));
         archive = File.ReadAllBytes(archivePath);
         File.Delete(archivePath);
-        return new MemoryStream(_archiveCache.GetOrAdd(runtimeVersion, archive));
+        return new MemoryStream(_archiveCache.GetOrAdd(versions, archive));
     }
 
     /// <summary>

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -267,7 +267,9 @@ public sealed class MockServer : IAsyncDisposable
                 var sdkVersion = SemVersion.Parse(channelIndex.LatestSdk, SemVersionStyles.Strict);
                 var route = $"/sdk/{sdkVersion}/dotnet-sdk-{sdkVersion}-{CurrentRID}{ZipSuffix}";
                 var unversioned = $"/sdk/{sdkVersion}/dotnet-sdk-{CurrentRID}{ZipSuffix}";
-                routes[route] = routes[unversioned] = GetSdk(sdkVersion, sdkVersion, sdkVersion, sdkVersion);
+                var handler = GetSdk(sdkVersion, sdkVersion, sdkVersion, sdkVersion);
+                routes.TryAdd(route, handler);
+                routes.TryAdd(unversioned, handler);
             }
             foreach (var v in _dailyBuilds)
             {
@@ -303,15 +305,25 @@ public sealed class MockServer : IAsyncDisposable
     private Action<HttpListenerResponse> GetChannelIndexJson(ChannelReleaseIndex index)
         => WriteJson(JsonSerializer.Serialize(index));
 
-    private static Action<HttpListenerResponse> GetSdk(
+    /// <summary>
+    /// Extra <c>sdk-manifests/&lt;band&gt;</c> directories to include in every served SDK archive,
+    /// mimicking the in-box workload manifests that real SDKs ship under older feature bands.
+    /// </summary>
+    public List<string> ExtraManifestBands { get; } = new();
+
+    private Action<HttpListenerResponse> GetSdk(
         SemVersion sdkVersion,
         SemVersion runtimeVersion,
         SemVersion aspnetVersion,
-        SemVersion winVersion) => response =>
+        SemVersion winVersion)
     {
-        using var f = Assets.GetSdkArchive(sdkVersion, runtimeVersion, aspnetVersion);
-        WriteOk(response, f);
-    };
+        var extraBands = ExtraManifestBands.ToList();
+        return response =>
+        {
+            using var f = Assets.GetSdkArchive(sdkVersion, runtimeVersion, aspnetVersion, winVersion, extraBands);
+            WriteOk(response, f);
+        };
+    }
 
     private void GetDnvm(HttpListenerResponse response)
     {

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -310,6 +310,7 @@ public sealed class MockServer : IAsyncDisposable
     /// mimicking the in-box workload manifests that real SDKs ship under older feature bands.
     /// </summary>
     public List<string> ExtraManifestBands { get; } = new();
+    public bool IncludeSdkManifestBand { get; set; } = true;
 
     private Action<HttpListenerResponse> GetSdk(
         SemVersion sdkVersion,
@@ -318,9 +319,16 @@ public sealed class MockServer : IAsyncDisposable
         SemVersion winVersion)
     {
         var extraBands = ExtraManifestBands.ToList();
+        var includeSdkManifestBand = IncludeSdkManifestBand;
         return response =>
         {
-            using var f = Assets.GetSdkArchive(sdkVersion, runtimeVersion, aspnetVersion, winVersion, extraBands);
+            using var f = Assets.GetSdkArchive(
+                sdkVersion,
+                runtimeVersion,
+                aspnetVersion,
+                winVersion,
+                extraBands,
+                includeSdkManifestBand);
             WriteOk(response, f);
         };
     }

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -87,6 +87,48 @@ public sealed class InstallTests
     });
 
     [Fact]
+    public Task ForceRefreshesLegacyOwnershipMetadata() => RunWithServer(async (server, env) =>
+    {
+        var version = MockServer.DefaultLtsVersion;
+        var options = new DnvmSubCommand.InstallArgs
+        {
+            SdkVersion = version,
+        };
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, options));
+
+        var manifest = await Manifest.ReadManifestUnsafe(env);
+        var original = Assert.Single(manifest.InstalledSdks);
+        Assert.NotNull(original.WindowsDesktopVersion);
+        Assert.NotEmpty(original.SdkManifestBands);
+
+        using (var @lock = await ManifestLock.Acquire(env))
+        {
+            manifest = manifest with
+            {
+                InstalledSdks =
+                [
+                    original with
+                    {
+                        WindowsDesktopVersion = null,
+                        SdkManifestBands = [],
+                    }
+                ]
+            };
+            await @lock.WriteManifest(env, manifest);
+        }
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, options with { Force = true }));
+
+        manifest = await Manifest.ReadManifestUnsafe(env);
+        var refreshed = Assert.Single(manifest.InstalledSdks);
+        Assert.Equal(original.WindowsDesktopVersion, refreshed.WindowsDesktopVersion);
+        Assert.Equal(original.SdkManifestBands, refreshed.SdkManifestBands);
+    });
+
+    [Fact]
     public Task InstallProgressInConsole() => RunWithServer(async (server, env) =>
     {
         var options = new DnvmSubCommand.InstallArgs

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -102,6 +102,7 @@ public sealed class InstallTests
         var original = Assert.Single(manifest.InstalledSdks);
         Assert.NotNull(original.WindowsDesktopVersion);
         Assert.NotEmpty(original.SdkManifestBands);
+        Assert.True(original.SdkManifestBandsKnown);
 
         using (var @lock = await ManifestLock.Acquire(env))
         {
@@ -113,6 +114,7 @@ public sealed class InstallTests
                     {
                         WindowsDesktopVersion = null,
                         SdkManifestBands = [],
+                        SdkManifestBandsKnown = false,
                     }
                 ]
             };
@@ -126,6 +128,7 @@ public sealed class InstallTests
         var refreshed = Assert.Single(manifest.InstalledSdks);
         Assert.Equal(original.WindowsDesktopVersion, refreshed.WindowsDesktopVersion);
         Assert.Equal(original.SdkManifestBands, refreshed.SdkManifestBands);
+        Assert.True(refreshed.SdkManifestBandsKnown);
     });
 
     [Fact]

--- a/test/UnitTests/ListTests.cs
+++ b/test/UnitTests/ListTests.cs
@@ -25,11 +25,13 @@ public sealed class ListTests
                 SdkVersion = new(1,0,0),
                 RuntimeVersion = new(1,0,0),
                 AspNetVersion = new(1,0,0),
+                WindowsDesktopVersion = new(1,0,0),
                 ReleaseVersion = new(1,0,0) }, new Channel.Latest())
             .AddSdk(new InstalledSdk() {
                 SdkVersion = previewVersion,
                 RuntimeVersion = previewVersion,
                 AspNetVersion = previewVersion,
+                WindowsDesktopVersion = previewVersion,
                 ReleaseVersion = previewVersion,
                 SdkDirName = new("preview") }, new Channel.Preview());
 
@@ -65,6 +67,7 @@ Tracked channels:
                 SdkVersion = new(42, 42, 42),
                 RuntimeVersion = new(42, 42, 42),
                 AspNetVersion = new(42, 42, 42),
+                WindowsDesktopVersion = new(42, 42, 42),
                 ReleaseVersion = new(42, 42, 42),
             }, new Channel.Latest());
 

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -122,6 +122,7 @@ public sealed class ManifestTests
                     AspNetVersion = new SemVersion(7, 0, 2),
                     WindowsDesktopVersion = new SemVersion(7, 0, 2),
                     SdkManifestBands = EqArray.Create("7.0.200"),
+                    SdkManifestBandsKnown = true,
                     SdkDirName = new SdkDirName("dn")
                 }
             ],
@@ -155,6 +156,7 @@ public sealed class ManifestTests
             "aspNetVersion":"7.0.2",
             "windowsDesktopVersion":"7.0.2",
             "sdkManifestBands":["7.0.200"],
+            "sdkManifestBandsKnown":true,
             "sdkDirName": "dn"
         }
     ],
@@ -202,6 +204,8 @@ public sealed class ManifestTests
             manifest,
             DnvmEnv.DefaultDotnetFeedUrls);
 
-        Assert.Null(Assert.Single(parsed.InstalledSdks).WindowsDesktopVersion);
+        var installedSdk = Assert.Single(parsed.InstalledSdks);
+        Assert.Null(installedSdk.WindowsDesktopVersion);
+        Assert.False(installedSdk.SdkManifestBandsKnown);
     }
 }

--- a/test/UnitTests/ManifestTests.cs
+++ b/test/UnitTests/ManifestTests.cs
@@ -1,3 +1,4 @@
+using StaticCs.Collections;
 
 using Dnvm;
 using Semver;
@@ -108,7 +109,7 @@ public sealed class ManifestTests
     });
 
     [Fact]
-    public void WriteManifestV9()
+    public void WriteManifestV10()
     {
         var manifest = new Manifest
         {
@@ -119,6 +120,8 @@ public sealed class ManifestTests
                     SdkVersion = new SemVersion(7, 0, 203),
                     RuntimeVersion = new SemVersion(7, 0, 2),
                     AspNetVersion = new SemVersion(7, 0, 2),
+                    WindowsDesktopVersion = new SemVersion(7, 0, 2),
+                    SdkManifestBands = EqArray.Create("7.0.200"),
                     SdkDirName = new SdkDirName("dn")
                 }
             ],
@@ -141,7 +144,7 @@ public sealed class ManifestTests
         };
         var expected = """
 {
-    "version":9,
+    "version":10,
     "previewsEnabled": false,
     "currentSdkDir": "dn",
     "installedSdks":[
@@ -150,6 +153,8 @@ public sealed class ManifestTests
             "sdkVersion":"7.0.203",
             "runtimeVersion":"7.0.2",
             "aspNetVersion":"7.0.2",
+            "windowsDesktopVersion":"7.0.2",
+            "sdkManifestBands":["7.0.200"],
             "sdkDirName": "dn"
         }
     ],
@@ -171,5 +176,32 @@ public sealed class ManifestTests
 """;
         var serialized = ManifestSerialize.Serialize(manifest);
         Assert.Equal(JsonSerializer.DeserializeJsonValue(expected), JsonSerializer.DeserializeJsonValue(serialized));
+    }
+
+    [Fact]
+    public async Task ManifestV9LeavesWindowsDesktopVersionUnknown()
+    {
+        var manifest = """
+{
+    "version":9,
+    "previewsEnabled":false,
+    "currentSdkDir":"dn",
+    "installedSdks":[{
+        "releaseVersion":"10.0.0-preview.1",
+        "sdkVersion":"10.0.100-preview.1.12345.6",
+        "runtimeVersion":"10.0.0-preview.1.12345.6",
+        "aspNetVersion":"10.0.0-preview.1.12345.7",
+        "sdkDirName":"dn"
+    }],
+    "registeredChannels":[]
+}
+""";
+
+        var parsed = await ManifestSerialize.DeserializeNewOrOldManifest(
+            new ScopedHttpClient(new HttpClient()),
+            manifest,
+            DnvmEnv.DefaultDotnetFeedUrls);
+
+        Assert.Null(Assert.Single(parsed.InstalledSdks).WindowsDesktopVersion);
     }
 }

--- a/test/UnitTests/PruneTests.cs
+++ b/test/UnitTests/PruneTests.cs
@@ -204,6 +204,7 @@ public sealed class PruneTests
                     SdkVersion = newVersion,
                     RuntimeVersion = newVersion,
                     AspNetVersion = newVersion,
+                    WindowsDesktopVersion = newVersion,
                     ReleaseVersion = newVersion,
                     SdkDirName = DnvmEnv.DefaultSdkDirName
                 }

--- a/test/UnitTests/TrackTests.cs
+++ b/test/UnitTests/TrackTests.cs
@@ -44,6 +44,7 @@ public sealed class TrackTests
             RuntimeVersion = installedVersion,
             WindowsDesktopVersion = installedVersion,
             SdkManifestBands = EqArray.Create((installedVersion).ToFeatureBand()),
+            SdkManifestBandsKnown = true,
             ReleaseVersion = installedVersion,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ];
@@ -142,6 +143,7 @@ public sealed class TrackTests
             AspNetVersion = releaseVersion,
             WindowsDesktopVersion = releaseVersion,
             SdkManifestBands = EqArray.Create((sdkVersion).ToFeatureBand()),
+            SdkManifestBandsKnown = true,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
         Assert.Equal([
@@ -173,6 +175,7 @@ public sealed class TrackTests
             AspNetVersion = version,
             WindowsDesktopVersion = version,
             SdkManifestBands = EqArray.Create((version).ToFeatureBand()),
+            SdkManifestBandsKnown = true,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
     });
@@ -192,6 +195,7 @@ public sealed class TrackTests
             AspNetVersion = version,
             WindowsDesktopVersion = version,
             SdkManifestBands = EqArray.Create((version).ToFeatureBand()),
+            SdkManifestBandsKnown = true,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
     });

--- a/test/UnitTests/TrackTests.cs
+++ b/test/UnitTests/TrackTests.cs
@@ -1,3 +1,4 @@
+using StaticCs.Collections;
 using System.Collections.Immutable;
 using Semver;
 using Spectre.Console.Testing;
@@ -41,6 +42,8 @@ public sealed class TrackTests
             SdkVersion = installedVersion,
             AspNetVersion = installedVersion,
             RuntimeVersion = installedVersion,
+            WindowsDesktopVersion = installedVersion,
+            SdkManifestBands = EqArray.Create((installedVersion).ToFeatureBand()),
             ReleaseVersion = installedVersion,
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ];
@@ -137,6 +140,8 @@ public sealed class TrackTests
             SdkVersion = sdkVersion,
             RuntimeVersion = releaseVersion,
             AspNetVersion = releaseVersion,
+            WindowsDesktopVersion = releaseVersion,
+            SdkManifestBands = EqArray.Create((sdkVersion).ToFeatureBand()),
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
         Assert.Equal([
@@ -166,6 +171,8 @@ public sealed class TrackTests
             SdkVersion = version,
             RuntimeVersion = version,
             AspNetVersion = version,
+            WindowsDesktopVersion = version,
+            SdkManifestBands = EqArray.Create((version).ToFeatureBand()),
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
     });
@@ -183,6 +190,8 @@ public sealed class TrackTests
             SdkVersion = version,
             RuntimeVersion = version,
             AspNetVersion = version,
+            WindowsDesktopVersion = version,
+            SdkManifestBands = EqArray.Create((version).ToFeatureBand()),
             SdkDirName = DnvmEnv.DefaultSdkDirName
         } ], manifest.InstalledSdks);
     });

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using StaticCs.Collections;
 
 using System.Net.Security;
 using Semver;
@@ -47,12 +49,83 @@ public sealed class UninstallTests
         Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
         Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "shared" / "Microsoft.AspNetCore.App" / ltsVersion.ToString()));
         Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "host" / "fxr" / ltsVersion.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / ltsVersion.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "packs" / "Microsoft.NETCore.App.Ref" / ltsVersion.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "packs" / "Microsoft.AspNetCore.App.Ref" / ltsVersion.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "packs" / "Microsoft.WindowsDesktop.App.Ref" / ltsVersion.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(UPath.Root / "dn" / "sdk-manifests" / ltsVersion.ToFeatureBand()));
 
         Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.NETCore.App" / previewVersion.ToString()));
         Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "shared" / "Microsoft.AspNetCore.App" / previewVersion.ToString()));
         Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "host" / "fxr" / previewVersion.ToString()));
         Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "packs" / $"Microsoft.NETCore.App.Host.{Utilities.CurrentRID}" / previewVersion.ToString()));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "packs" / "Microsoft.NETCore.App.Ref" / previewVersion.ToString()));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "packs" / "Microsoft.AspNetCore.App.Ref" / previewVersion.ToString()));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "packs" / "Microsoft.WindowsDesktop.App.Ref" / previewVersion.ToString()));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "sdk-manifests" / previewVersion.ToFeatureBand()));
         Assert.True(env.DnvmHomeFs.DirectoryExists(UPath.Root / "preview" / "templates" / previewVersion.ToString()));
+    });
+
+    [Fact]
+    public Task DirectorySpecificUninstallKeepsOtherCopy() => RunWithServer(async (server, env) =>
+    {
+        var version = MockServer.DefaultLtsVersion;
+        var previewDir = new SdkDirName("preview");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs
+            {
+                SdkVersion = version,
+            }));
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs
+            {
+                SdkVersion = version,
+                SdkDir = previewDir,
+            }));
+
+        using (var @lock = await ManifestLock.Acquire(env))
+        {
+            var manifest = await @lock.ReadManifest(env);
+            manifest = manifest with
+            {
+                RegisteredChannels =
+                [
+                    new RegisteredChannel
+                    {
+                        ChannelName = new Channel.Latest(),
+                        SdkDirName = DnvmEnv.DefaultSdkDirName,
+                        InstalledSdkVersions = [version],
+                    },
+                    new RegisteredChannel
+                    {
+                        ChannelName = new Channel.Latest(),
+                        SdkDirName = previewDir,
+                        InstalledSdkVersions = [version],
+                    },
+                ]
+            };
+            await @lock.WriteManifest(env, manifest);
+        }
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, version, previewDir));
+
+        var updated = await Manifest.ReadManifestUnsafe(env);
+        Assert.Contains(updated.InstalledSdks,
+            sdk => sdk.SdkVersion == version && sdk.SdkDirName == DnvmEnv.DefaultSdkDirName);
+        Assert.DoesNotContain(updated.InstalledSdks,
+            sdk => sdk.SdkVersion == version && sdk.SdkDirName == previewDir);
+        Assert.Contains(updated.RegisteredChannels,
+            channel => channel.SdkDirName == DnvmEnv.DefaultSdkDirName
+                && channel.InstalledSdkVersions.Contains(version));
+        Assert.Contains(updated.RegisteredChannels,
+            channel => channel.SdkDirName == previewDir
+                && !channel.InstalledSdkVersions.Contains(version));
+
+        Assert.True(env.DnvmHomeFs.DirectoryExists(
+            UPath.Root / DnvmEnv.DefaultSdkDirName.Name / "sdk" / version.ToString()));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(
+            UPath.Root / previewDir.Name / "sdk" / version.ToString()));
     });
 
     [Fact]
@@ -80,6 +153,267 @@ public sealed class UninstallTests
         Assert.Equal(0, unResult);
         Assert.DoesNotContain("SdkDirName", actualOutput);
         Assert.DoesNotContain(ltsVersion.ToString(), actualOutput);
+    });
+
+    [Fact]
+    public Task SharedFeatureBandKept() => RunWithServer(async (server, env) =>
+    {
+        // Two SDKs in the same feature band (42.42.100 and 42.42.101 -> band 42.42.100)
+        var firstVersion = new SemVersion(42, 42, 100);
+        var secondVersion = new SemVersion(42, 42, 101);
+        server.RegisterReleaseVersion(firstVersion, "lts", "active");
+        server.RegisterReleaseVersion(secondVersion, "lts", "active");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = firstVersion }));
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = secondVersion }));
+
+        var band = firstVersion.ToFeatureBand();
+        Assert.Equal(band, secondVersion.ToFeatureBand());
+        var bandDir = UPath.Root / "dn" / "sdk-manifests" / band;
+        Assert.True(env.DnvmHomeFs.DirectoryExists(bandDir));
+
+        // Uninstalling one SDK must keep the band manifests since the other still shares it
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, firstVersion));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(bandDir));
+
+        // Uninstalling the last SDK in the band removes the manifests
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, secondVersion));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(bandDir));
+    });
+
+    [Fact]
+    public Task Dotnet6PrereleaseSharesStableFeatureBand() => RunWithServer(async (server, env) =>
+    {
+        var stableVersion = new SemVersion(6, 0, 100);
+        var previewVersion = SemVersion.Parse("6.0.100-rc.2.21505.57", SemVersionStyles.Strict);
+        server.RegisterReleaseVersion(stableVersion, "lts", "active");
+        server.RegisterReleaseVersion(previewVersion, "lts", "preview");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = stableVersion }));
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = previewVersion }));
+
+        var band = stableVersion.ToFeatureBand();
+        Assert.Equal(band, previewVersion.ToFeatureBand());
+        var bandDir = UPath.Root / "dn" / "sdk-manifests" / band;
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, stableVersion));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(bandDir));
+    });
+
+    [Fact]
+    public Task LaggingWorkloadBandKept() => RunWithServer(async (server, env) =>
+    {
+        // A single SDK archive lays down manifests under its own band *and* under an older band
+        // used by the in-box mobile workloads. Two SDKs in different feature bands still share
+        // that older band, so uninstalling one must not delete it.
+        const string laggingBand = "42.42.100-mobile";
+        server.ExtraManifestBands.Add(laggingBand);
+
+        var firstVersion = new SemVersion(42, 42, 100);
+        var secondVersion = new SemVersion(42, 42, 200);
+        server.RegisterReleaseVersion(firstVersion, "lts", "active");
+        server.RegisterReleaseVersion(secondVersion, "lts", "active");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = firstVersion }));
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = secondVersion }));
+
+        Assert.NotEqual(firstVersion.ToFeatureBand(), secondVersion.ToFeatureBand());
+
+        var laggingDir = UPath.Root / "dn" / "sdk-manifests" / laggingBand;
+        var secondBandDir = UPath.Root / "dn" / "sdk-manifests" / secondVersion.ToFeatureBand();
+        Assert.True(env.DnvmHomeFs.DirectoryExists(laggingDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(secondBandDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, secondVersion));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(secondBandDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(laggingDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, firstVersion));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(laggingDir));
+    });
+
+    [Fact]
+    public Task ManifestBandsAreAttributedToTheirArchive() => RunWithServer(async (server, env) =>
+    {
+        const string firstArchiveOnlyBand = "42.42.100-mobile";
+        var firstVersion = new SemVersion(42, 42, 100);
+        var secondVersion = new SemVersion(42, 42, 200);
+        server.RegisterReleaseVersion(firstVersion, "lts", "active");
+        server.RegisterReleaseVersion(secondVersion, "lts", "active");
+
+        server.ExtraManifestBands.Add(firstArchiveOnlyBand);
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = firstVersion }));
+
+        server.ExtraManifestBands.Clear();
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = secondVersion }));
+
+        var manifest = await Manifest.ReadManifestUnsafe(env);
+        var firstSdk = Assert.Single(manifest.InstalledSdks, sdk => sdk.SdkVersion == firstVersion);
+        var secondSdk = Assert.Single(manifest.InstalledSdks, sdk => sdk.SdkVersion == secondVersion);
+        Assert.Contains(firstArchiveOnlyBand, firstSdk.SdkManifestBands);
+        Assert.DoesNotContain(firstArchiveOnlyBand, secondSdk.SdkManifestBands);
+
+        var firstArchiveOnlyDir = UPath.Root / "dn" / "sdk-manifests" / firstArchiveOnlyBand;
+        Assert.True(env.DnvmHomeFs.DirectoryExists(firstArchiveOnlyDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, firstVersion));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(firstArchiveOnlyDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(
+            UPath.Root / "dn" / "sdk-manifests" / secondVersion.ToFeatureBand()));
+    });
+
+    [Fact]
+    public Task UnknownLegacyManifestBandsProtectsDirectory() => RunWithServer(async (server, env) =>
+    {
+        // An SDK installed by an older dnvm has no recorded manifest bands. We can't know which
+        // band directories it needs, so no sdk-manifests cleanup may happen in that directory.
+        var legacyVersion = new SemVersion(42, 42, 100);
+        var newVersion = new SemVersion(42, 42, 200);
+        server.RegisterReleaseVersion(legacyVersion, "lts", "active");
+        server.RegisterReleaseVersion(newVersion, "lts", "active");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = legacyVersion }));
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = newVersion }));
+
+        using (var @lock = await ManifestLock.Acquire(env))
+        {
+            var manifest = await @lock.ReadManifest(env);
+            manifest = manifest with
+            {
+                InstalledSdks = manifest.InstalledSdks
+                    .Select(sdk => sdk.SdkVersion == legacyVersion
+                        ? sdk with { SdkManifestBands = EqArray<string>.Empty }
+                        : sdk)
+                    .ToEq()
+            };
+            await @lock.WriteManifest(env, manifest);
+        }
+
+        var newBandDir = UPath.Root / "dn" / "sdk-manifests" / newVersion.ToFeatureBand();
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, newVersion));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(newBandDir));
+    });
+
+    [Fact]
+    public Task WorkloadMetadataKeepsFeatureBand() => RunWithServer(async (server, env) =>
+    {
+        var version = new SemVersion(42, 42, 100);
+        server.RegisterReleaseVersion(version, "lts", "active");
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = version }));
+
+        var band = version.ToFeatureBand();
+        var bandDir = UPath.Root / "dn" / "sdk-manifests" / band;
+        var workloadRecord = UPath.Root / "dn" / "metadata" / "workloads" / "InstalledPacks"
+            / "v1" / "Some.Workload.Pack" / "1.0.0" / band;
+        env.DnvmHomeFs.CreateDirectory(workloadRecord.GetDirectory());
+        env.DnvmHomeFs.WriteAllText(workloadRecord, "");
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, version));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(bandDir));
+    });
+
+    [Fact]
+    public Task WindowsDesktopComponentVersionUsed() => RunWithServer(async (server, env) =>
+    {
+        var sdkVersion = SemVersion.Parse("10.0.100-preview.1.12345.6", SemVersionStyles.Strict);
+        var releaseVersion = SemVersion.Parse("10.0.0-preview.1", SemVersionStyles.Strict);
+        var runtimeVersion = SemVersion.Parse("10.0.0-preview.1.12345.7", SemVersionStyles.Strict);
+        var windowsDesktopVersion = SemVersion.Parse("10.0.0-preview.1.12345.8", SemVersionStyles.Strict);
+        var release = server.RegisterReleaseVersion(sdkVersion, "sts", "preview");
+        release = release with
+        {
+            ReleaseVersion = releaseVersion,
+            Runtime = release.Runtime with { Version = runtimeVersion },
+            WindowsDesktop = release.WindowsDesktop with { Version = windowsDesktopVersion },
+        };
+        server.ChannelIndexMap[sdkVersion.ToMajorMinor()] = new() { Releases = [release] };
+
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs { SdkVersion = sdkVersion }));
+
+        var installed = Assert.Single((await Manifest.ReadManifestUnsafe(env)).InstalledSdks);
+        Assert.Equal(windowsDesktopVersion, installed.WindowsDesktopVersion);
+        var sharedDir = UPath.Root / "dn" / "shared" / "Microsoft.WindowsDesktop.App" / windowsDesktopVersion.ToString();
+        var refPackDir = UPath.Root / "dn" / "packs" / "Microsoft.WindowsDesktop.App.Ref" / windowsDesktopVersion.ToString();
+        Assert.True(env.DnvmHomeFs.DirectoryExists(sharedDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(refPackDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, sdkVersion));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(sharedDir));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(refPackDir));
+    });
+
+    [Fact]
+    public Task UnknownLegacyWindowsDesktopVersionKept() => RunWithServer(async (server, env) =>
+    {
+        var sdkVersion = new SemVersion(10, 0, 100);
+        var runtimeVersion = new SemVersion(10, 0, 0);
+        var windowsDesktopVersion = SemVersion.Parse("10.0.0-preview.1.12345.8", SemVersionStyles.Strict);
+        var manifest = Manifest.Empty.AddSdk(new InstalledSdk
+        {
+            SdkVersion = sdkVersion,
+            ReleaseVersion = runtimeVersion,
+            RuntimeVersion = runtimeVersion,
+            AspNetVersion = runtimeVersion,
+            WindowsDesktopVersion = null,
+        });
+        await Manifest.WriteManifestUnsafe(env, manifest);
+
+        var sharedDir = UPath.Root / "dn" / "shared" / "Microsoft.WindowsDesktop.App" / windowsDesktopVersion.ToString();
+        var refPackDir = UPath.Root / "dn" / "packs" / "Microsoft.WindowsDesktop.App.Ref" / windowsDesktopVersion.ToString();
+        env.DnvmHomeFs.CreateDirectory(sharedDir);
+        env.DnvmHomeFs.CreateDirectory(refPackDir);
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, sdkVersion));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(sharedDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(refPackDir));
+    });
+
+    [Fact]
+    public Task UnknownLegacyWindowsDesktopVersionProtectsDirectory() => RunWithServer(async (server, env) =>
+    {
+        var legacySdkVersion = new SemVersion(9, 0, 100);
+        var knownSdkVersion = new SemVersion(10, 0, 100);
+        var windowsDesktopVersion = new SemVersion(10, 0, 0);
+        var manifest = Manifest.Empty
+            .AddSdk(new InstalledSdk
+            {
+                SdkVersion = legacySdkVersion,
+                ReleaseVersion = new SemVersion(9, 0, 0),
+                RuntimeVersion = new SemVersion(9, 0, 0),
+                AspNetVersion = new SemVersion(9, 0, 0),
+                WindowsDesktopVersion = null,
+            })
+            .AddSdk(new InstalledSdk
+            {
+                SdkVersion = knownSdkVersion,
+                ReleaseVersion = windowsDesktopVersion,
+                RuntimeVersion = windowsDesktopVersion,
+                AspNetVersion = windowsDesktopVersion,
+                WindowsDesktopVersion = windowsDesktopVersion,
+            });
+        await Manifest.WriteManifestUnsafe(env, manifest);
+
+        var sharedDir = UPath.Root / "dn" / "shared" / "Microsoft.WindowsDesktop.App" / windowsDesktopVersion.ToString();
+        var refPackDir = UPath.Root / "dn" / "packs" / "Microsoft.WindowsDesktop.App.Ref" / windowsDesktopVersion.ToString();
+        env.DnvmHomeFs.CreateDirectory(sharedDir);
+        env.DnvmHomeFs.CreateDirectory(refPackDir);
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, knownSdkVersion));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(sharedDir));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(refPackDir));
     });
 
     [Fact]

--- a/test/UnitTests/UninstallTests.cs
+++ b/test/UnitTests/UninstallTests.cs
@@ -329,7 +329,11 @@ public sealed class UninstallTests
             {
                 InstalledSdks = manifest.InstalledSdks
                     .Select(sdk => sdk.SdkVersion == legacyVersion
-                        ? sdk with { SdkManifestBands = EqArray<string>.Empty }
+                        ? sdk with
+                        {
+                            SdkManifestBands = EqArray<string>.Empty,
+                            SdkManifestBandsKnown = false,
+                        }
                         : sdk)
                     .ToEq()
             };
@@ -339,6 +343,42 @@ public sealed class UninstallTests
         var newBandDir = UPath.Root / "dn" / "sdk-manifests" / newVersion.ToFeatureBand();
         Assert.Equal(0, await UninstallCommand.Run(env, _logger, newVersion));
         Assert.True(env.DnvmHomeFs.DirectoryExists(newBandDir));
+    });
+
+    [Fact]
+    public Task KnownEmptyManifestBandsDoNotProtectDirectory() => RunWithServer(async (server, env) =>
+    {
+        var emptyArchiveVersion = new SemVersion(5, 0, 408);
+        var versionWithManifests = new SemVersion(8, 0, 100);
+        server.RegisterReleaseVersion(emptyArchiveVersion, "lts", "eol");
+        server.RegisterReleaseVersion(versionWithManifests, "lts", "active");
+
+        server.IncludeSdkManifestBand = false;
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs
+            {
+                SdkVersion = emptyArchiveVersion,
+            }));
+
+        server.IncludeSdkManifestBand = true;
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs
+            {
+                SdkVersion = versionWithManifests,
+            }));
+
+        var manifest = await Manifest.ReadManifestUnsafe(env);
+        var emptyArchiveSdk = Assert.Single(
+            manifest.InstalledSdks,
+            sdk => sdk.SdkVersion == emptyArchiveVersion);
+        Assert.Empty(emptyArchiveSdk.SdkManifestBands);
+        Assert.True(emptyArchiveSdk.SdkManifestBandsKnown);
+
+        var manifestsDir = UPath.Root / "dn" / "sdk-manifests" / versionWithManifests.ToFeatureBand();
+        Assert.True(env.DnvmHomeFs.DirectoryExists(manifestsDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, versionWithManifests));
+        Assert.False(env.DnvmHomeFs.DirectoryExists(manifestsDir));
     });
 
     [Fact]
@@ -359,6 +399,31 @@ public sealed class UninstallTests
 
         Assert.Equal(0, await UninstallCommand.Run(env, _logger, version));
         Assert.True(env.DnvmHomeFs.DirectoryExists(bandDir));
+    });
+
+    [Theory]
+    [InlineData("Microsoft.NETCore.App.Ref")]
+    [InlineData("Microsoft.AspNetCore.App.Ref")]
+    [InlineData("Microsoft.WindowsDesktop.App.Ref")]
+    public Task WorkloadMetadataKeepsReferencedPack(string packId) => RunWithServer(async (server, env) =>
+    {
+        var version = MockServer.DefaultLtsVersion;
+        Assert.Equal(InstallCommand.Result.Success,
+            await InstallCommand.Run(env, _logger, new DnvmSubCommand.InstallArgs
+            {
+                SdkVersion = version,
+            }));
+
+        var workloadRecord = UPath.Root / "dn" / "metadata" / "workloads" / "InstalledPacks"
+            / "v1" / packId / version.ToString() / version.ToFeatureBand();
+        env.DnvmHomeFs.CreateDirectory(workloadRecord.GetDirectory());
+        env.DnvmHomeFs.WriteAllText(workloadRecord, "");
+
+        var packDir = UPath.Root / "dn" / "packs" / packId / version.ToString();
+        Assert.True(env.DnvmHomeFs.DirectoryExists(packDir));
+
+        Assert.Equal(0, await UninstallCommand.Run(env, _logger, version));
+        Assert.True(env.DnvmHomeFs.DirectoryExists(packDir));
     });
 
     [Fact]

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -1,3 +1,4 @@
+using StaticCs.Collections;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices.Marshalling;
 using System.Security.Cryptography;
@@ -41,6 +42,8 @@ public sealed class UpdateTests
                 SdkVersion = new(42, 42, 142),
                 AspNetVersion = new(42, 42, 142),
                 RuntimeVersion = new(42, 42, 142),
+                WindowsDesktopVersion = new(42, 42, 142),
+                SdkManifestBands = EqArray.Create((new SemVersion(42, 42, 142)).ToFeatureBand()),
                 ReleaseVersion = new(42, 42, 142),
                 SdkDirName = sdkDir
             } ],
@@ -78,6 +81,8 @@ public sealed class UpdateTests
                 SdkDirName = DnvmEnv.DefaultSdkDirName,
                 AspNetVersion = installedVersion,
                 RuntimeVersion = installedVersion,
+                WindowsDesktopVersion = installedVersion,
+                SdkManifestBands = EqArray.Create((installedVersion).ToFeatureBand()),
                 ReleaseVersion = installedVersion,
             }] ,
             RegisteredChannels = [ new RegisteredChannel {
@@ -120,6 +125,8 @@ public sealed class UpdateTests
                 SdkVersion = v,
                 AspNetVersion = v,
                 RuntimeVersion = v,
+                WindowsDesktopVersion = v,
+                SdkManifestBands = EqArray.Create((v).ToFeatureBand()),
                 ReleaseVersion = v,
                 SdkDirName = DnvmEnv.DefaultSdkDirName }).ToEq(),
             RegisteredChannels = [ new RegisteredChannel() {
@@ -276,12 +283,16 @@ public sealed class UpdateTests
                 ReleaseVersion = oldReleaseVersion,
                 RuntimeVersion = oldReleaseVersion,
                 AspNetVersion = oldReleaseVersion,
+                WindowsDesktopVersion = oldReleaseVersion,
+                SdkManifestBands = EqArray.Create((oldSdkVersion).ToFeatureBand()),
             },
             new() {
                 SdkVersion = newSdkVersion,
                 ReleaseVersion = newSdkVersion,
                 RuntimeVersion = newSdkVersion,
                 AspNetVersion = newSdkVersion,
+                WindowsDesktopVersion = newSdkVersion,
+                SdkManifestBands = EqArray.Create((newSdkVersion).ToFeatureBand()),
             } ], manifest.InstalledSdks);
         Assert.Equal([
             new() {
@@ -385,6 +396,8 @@ public sealed class UpdateTests
                 ReleaseVersion = initialVersion,
                 RuntimeVersion = initialVersion,
                 AspNetVersion = initialVersion,
+                WindowsDesktopVersion = initialVersion,
+                SdkManifestBands = EqArray.Create((initialVersion).ToFeatureBand()),
                 SdkDirName = DnvmEnv.DefaultSdkDirName
             },
             new InstalledSdk
@@ -393,6 +406,8 @@ public sealed class UpdateTests
                 ReleaseVersion = updatedVersion,
                 RuntimeVersion = updatedVersion,
                 AspNetVersion = updatedVersion,
+                WindowsDesktopVersion = updatedVersion,
+                SdkManifestBands = EqArray.Create((updatedVersion).ToFeatureBand()),
                 SdkDirName = DnvmEnv.DefaultSdkDirName
             },
             new InstalledSdk
@@ -401,6 +416,8 @@ public sealed class UpdateTests
                 ReleaseVersion = updatedVersion,
                 RuntimeVersion = updatedVersion,
                 AspNetVersion = updatedVersion,
+                WindowsDesktopVersion = updatedVersion,
+                SdkManifestBands = EqArray.Create((updatedVersion).ToFeatureBand()),
                 SdkDirName = new("custom-sdk-dir")
             }
         ], manifest.InstalledSdks);

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -44,6 +44,7 @@ public sealed class UpdateTests
                 RuntimeVersion = new(42, 42, 142),
                 WindowsDesktopVersion = new(42, 42, 142),
                 SdkManifestBands = EqArray.Create((new SemVersion(42, 42, 142)).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 ReleaseVersion = new(42, 42, 142),
                 SdkDirName = sdkDir
             } ],
@@ -83,6 +84,7 @@ public sealed class UpdateTests
                 RuntimeVersion = installedVersion,
                 WindowsDesktopVersion = installedVersion,
                 SdkManifestBands = EqArray.Create((installedVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 ReleaseVersion = installedVersion,
             }] ,
             RegisteredChannels = [ new RegisteredChannel {
@@ -127,6 +129,7 @@ public sealed class UpdateTests
                 RuntimeVersion = v,
                 WindowsDesktopVersion = v,
                 SdkManifestBands = EqArray.Create((v).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 ReleaseVersion = v,
                 SdkDirName = DnvmEnv.DefaultSdkDirName }).ToEq(),
             RegisteredChannels = [ new RegisteredChannel() {
@@ -285,6 +288,7 @@ public sealed class UpdateTests
                 AspNetVersion = oldReleaseVersion,
                 WindowsDesktopVersion = oldReleaseVersion,
                 SdkManifestBands = EqArray.Create((oldSdkVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
             },
             new() {
                 SdkVersion = newSdkVersion,
@@ -293,6 +297,7 @@ public sealed class UpdateTests
                 AspNetVersion = newSdkVersion,
                 WindowsDesktopVersion = newSdkVersion,
                 SdkManifestBands = EqArray.Create((newSdkVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
             } ], manifest.InstalledSdks);
         Assert.Equal([
             new() {
@@ -398,6 +403,7 @@ public sealed class UpdateTests
                 AspNetVersion = initialVersion,
                 WindowsDesktopVersion = initialVersion,
                 SdkManifestBands = EqArray.Create((initialVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 SdkDirName = DnvmEnv.DefaultSdkDirName
             },
             new InstalledSdk
@@ -408,6 +414,7 @@ public sealed class UpdateTests
                 AspNetVersion = updatedVersion,
                 WindowsDesktopVersion = updatedVersion,
                 SdkManifestBands = EqArray.Create((updatedVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 SdkDirName = DnvmEnv.DefaultSdkDirName
             },
             new InstalledSdk
@@ -418,6 +425,7 @@ public sealed class UpdateTests
                 AspNetVersion = updatedVersion,
                 WindowsDesktopVersion = updatedVersion,
                 SdkManifestBands = EqArray.Create((updatedVersion).ToFeatureBand()),
+                SdkManifestBandsKnown = true,
                 SdkDirName = new("custom-sdk-dir")
             }
         ], manifest.InstalledSdks);

--- a/test/UnitTests/UtilitiesTests.cs
+++ b/test/UnitTests/UtilitiesTests.cs
@@ -1,0 +1,21 @@
+using Semver;
+using Xunit;
+
+namespace Dnvm.Test;
+
+public sealed class UtilitiesTests
+{
+    [Theory]
+    [InlineData("6.0.105-rc.2.21505.57", "6.0.100")]
+    [InlineData("8.0.105", "8.0.100")]
+    [InlineData("8.0.105-preview.1.12345", "8.0.100-preview.1")]
+    [InlineData("8.0.105-rc.2.12345", "8.0.100-rc.2")]
+    [InlineData("8.0.105-dev.12345", "8.0.100")]
+    [InlineData("8.0.105-ci.12345", "8.0.100")]
+    [InlineData("8.0.105-rtm.12345", "8.0.100")]
+    public void ToFeatureBandMatchesDotnetSdk(string version, string expected)
+    {
+        var sdkVersion = SemVersion.Parse(version, SemVersionStyles.Strict);
+        Assert.Equal(expected, sdkVersion.ToFeatureBand());
+    }
+}


### PR DESCRIPTION
## Summary

- remove SDK-owned runtime, ASP.NET, and Windows Desktop reference packs when no installed SDK still needs them
- preserve packs referenced by workload installation metadata
- record the exact `sdk-manifests` feature bands contributed by each SDK archive
- safely prune manifest bands only when no SDK or workload still references them
- distinguish legacy-unknown ownership from archives known to contain no workload manifests
- refresh cleanup metadata on forced reinstall
- add manifest schema v10 for Windows Desktop component versions and manifest ownership

Workload-owned packs such as iOS, Android, Mono, and AOT cross-compilation packs are not removed.

## Testing

- `dotnet test test/UnitTests/UnitTests.csproj --nologo` (196 passed)
- `dotnet test test/IntegrationTests/IntegrationTests.csproj --nologo` (18 passed, 1 skipped)